### PR TITLE
Allow use of Zygote or ReverseDiff

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -23,4 +23,4 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 
 [targets]
-test = ["NLPModelsModifiers", "NLPModelsTest", "Test", "Zygote", "ReverseDiff"]
+test = ["NLPModelsModifiers", "NLPModelsTest", "ReverseDiff", "Test", "Zygote"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,17 +6,21 @@ version = "0.1.0"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
+Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
 ForwardDiff = "0.9.0, 0.10.0"
 NLPModels = "0.14"
+Requires = "1"
 julia = "^1.3.0"
 
 [extras]
 NLPModelsModifiers = "e01155f1-5c6f-4375-a9d8-616dd036575f"
 NLPModelsTest = "7998695d-6960-4d3a-85c4-e1bceb8cd856"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
+ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 
 [targets]
-test = ["NLPModelsModifiers", "NLPModelsTest", "Test"]
+test = ["NLPModelsModifiers", "NLPModelsTest", "Test", "Zygote", "ReverseDiff"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # ADNLPModels
 
-This package provides a very simple model implement the [NLPModels](https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl) API.
+This package provides a very simple model implement the [NLPModels](https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl) API. The following packages are supported:
+- `ForwardDiff.jl`: default choice.
+- `Zygote.jl`: you must load `Zygote.jl` separately and pass `ADNLPModels.ZygoteAD()` as the `adbackend` keyword argument to the `ADNLPModel` or `ADNLSModel` constructor.
+- `ReverseDiff.jl`: you must load `ReverseDiff.jl` separately and pass `ADNLPModels.ReverseDiffAD()` as the `adbackend` keyword argument to the `ADNLPModel` or `ADNLSModel` constructor.
 
 ## How to Cite
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ADNLPModels
 
-This package provides a very simple model implement the [NLPModels](https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl) API. The following packages are supported:
+This package provides AD-based model implementations that conform to the [NLPModels](https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl) API. The following packages are supported:
 - `ForwardDiff.jl`: default choice.
 - `Zygote.jl`: you must load `Zygote.jl` separately and pass `ADNLPModels.ZygoteAD()` as the `adbackend` keyword argument to the `ADNLPModel` or `ADNLSModel` constructor.
 - `ReverseDiff.jl`: you must load `ReverseDiff.jl` separately and pass `ADNLPModels.ReverseDiffAD()` as the `adbackend` keyword argument to the `ADNLPModel` or `ADNLSModel` constructor.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # ADNLPModels
 
 This package provides a very simple model implement the [NLPModels](https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl) API.
-It uses [`ForwardDiff`](https://github.com/JuliaDiff/ForwardDiff.jl) to compute the derivatives, which produces dense matrices, so it isn't very efficient for larger problems.
 
 ## How to Cite
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,7 +1,6 @@
 # ADNLPModelss
 
 This package provides a very simple model implement the [NLPModels](https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl) API.
-It uses [`ForwardDiff`](https://github.com/JuliaDiff/ForwardDiff.jl) to compute the derivatives, which produces dense matrices, so it isn't very efficient for larger problems.
 
 ## Install
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,6 @@
 # ADNLPModelss
 
-This package provides a very simple model implement the [NLPModels](https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl) API. The following packages are supported:
+This package provides AD-based model implementations that conform to the [NLPModels](https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl) API. The following packages are supported:
 - `ForwardDiff.jl`: default choice.
 - `Zygote.jl`: you must load `Zygote.jl` separately and pass `ADNLPModels.ZygoteAD()` as the `adbackend` keyword argument to the `ADNLPModel` or `ADNLSModel` constructor.
 - `ReverseDiff.jl`: you must load `ReverseDiff.jl` separately and pass `ADNLPModels.ReverseDiffAD()` as the `adbackend` keyword argument to the `ADNLPModel` or `ADNLSModel` constructor.

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,6 +1,9 @@
 # ADNLPModelss
 
-This package provides a very simple model implement the [NLPModels](https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl) API.
+This package provides a very simple model implement the [NLPModels](https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl) API. The following packages are supported:
+- `ForwardDiff.jl`: default choice.
+- `Zygote.jl`: you must load `Zygote.jl` separately and pass `ADNLPModels.ZygoteAD()` as the `adbackend` keyword argument to the `ADNLPModel` or `ADNLSModel` constructor.
+- `ReverseDiff.jl`: you must load `ReverseDiff.jl` separately and pass `ADNLPModels.ReverseDiffAD()` as the `adbackend` keyword argument to the `ADNLPModel` or `ADNLSModel` constructor.
 
 ## Install
 

--- a/src/ADNLPModels.jl
+++ b/src/ADNLPModels.jl
@@ -6,7 +6,9 @@ using LinearAlgebra
 using ForwardDiff
 # JSO
 using NLPModels
+using Requires
 
+include("ad.jl")
 include("nlp.jl")
 include("nls.jl")
 

--- a/src/ad.jl
+++ b/src/ad.jl
@@ -1,0 +1,74 @@
+abstract type ADBackend end
+struct ForwardDiffAD <: ADBackend end
+struct ZygoteAD <: ADBackend end
+struct ReverseDiffAD <: ADBackend end
+
+throw_error(b) = throw(ArgumentError("The AD backend $b is not loaded. Please load the corresponding AD package."))
+gradient(b::ADBackend, ::Any, ::Any) = throw_error(b)
+gradient!(b::ADBackend, ::Any, ::Any, ::Any) = throw_error(b)
+jacobian(b::ADBackend, ::Any, ::Any) = throw_error(b)
+hessian(b::ADBackend, ::Any, ::Any) = throw_error(b)
+pushforward(b::ADBackend, ::Any, ::Any, ::Any) = throw_error(b)
+pullback(b::ADBackend, ::Any, ::Any, ::Any) = throw_error(b)
+# Use FD for these always
+function directional_derivative(::ADBackend, f, x, v)
+    return ForwardDiff.derivative(t -> f(x + t * v), 0)
+end
+function directional_second_derivative(::ADBackend, f, x, v, w)
+    return ForwardDiff.derivative(
+        t -> ForwardDiff.derivative(
+            s -> f(x + s * w + t * v), 0,
+        ), 0,
+    )
+end
+function hvprod(b::ADBackend, f, x, v)
+    return ForwardDiff.derivative(t -> gradient(b, f, x + t * v), 0)
+end
+
+gradient(::ForwardDiffAD, f, x) = ForwardDiff.gradient(f, x)
+function gradient!(::ForwardDiffAD, g, f, x)
+    return ForwardDiff.gradient!(g, f, x)
+end
+jacobian(::ForwardDiffAD, f, x) = ForwardDiff.jacobian(f, x)
+hessian(::ForwardDiffAD, f, x) = ForwardDiff.hessian(f, x)
+function pushforward(::ForwardDiffAD, f, x, v)
+    return ForwardDiff.derivative(
+        t -> ForwardDiff.gradient(f, x + t * v), 0,
+    )
+end
+function pullback(::ForwardDiffAD, f, x, v)
+    return ForwardDiff.gradient(x -> dot(f(x), v), x)
+end
+
+@init begin
+    @require Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f" begin
+        gradient(::ZygoteAD, f, x) = Zygote.gradient(f, x)[1]
+        gradient!(::ZygoteAD, g, f, x) = g .= Zygote.gradient(f, x)[1]
+        jacobian(::ZygoteAD, f, x) = Zygote.jacobian(f, x)[1]
+        hessian(::ZygoteAD, f, x) = Zygote.hessian(f, x)
+        function pushforward(::ZygoteAD, f, x, v)
+            return ForwardDiff.derivative(
+                t -> Zygote.gradient(f, x + t * v), 0,
+            )
+        end
+        function pullback(::ZygoteAD, f, x, v)
+            return Zygote.gradient(x -> dot(f(x), v), x)[1]
+        end
+    end
+    @require ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267" begin
+        gradient(::ReverseDiffAD, f, x) = ReverseDiff.gradient(f, x)
+        function gradient!(::ReverseDiffAD, g, f, x)
+            return ReverseDiff.gradient!(g, f, x)
+        end
+        jacobian(::ReverseDiffAD, f, x) = ReverseDiff.jacobian(f, x)
+        hessian(::ReverseDiffAD, f, x) = ReverseDiff.hessian(f, x)
+        function pushforward(::ReverseDiffAD, f, x, v)
+            return ForwardDiff.derivative(
+                t -> ReverseDiff.gradient(f, x + t * v), 0,
+            )
+        end
+        function pullback(::ReverseDiffAD, f, x, v)
+            return ReverseDiff.gradient(x -> dot(f(x), v), x)
+        end
+    end
+end

--- a/src/ad.jl
+++ b/src/ad.jl
@@ -8,7 +8,7 @@ gradient(b::ADBackend, ::Any, ::Any) = throw_error(b)
 gradient!(b::ADBackend, ::Any, ::Any, ::Any) = throw_error(b)
 jacobian(b::ADBackend, ::Any, ::Any) = throw_error(b)
 hessian(b::ADBackend, ::Any, ::Any) = throw_error(b)
-directional_derivative(b::ADBackend, ::Any, ::Any, ::Any) = throw_error(b)
+pushforward(b::ADBackend, ::Any, ::Any, ::Any) = throw_error(b)
 pullback(b::ADBackend, ::Any, ::Any, ::Any) = throw_error(b)
 function directional_second_derivative(::ADBackend, f, x, v, w)
     return ForwardDiff.derivative(
@@ -27,7 +27,7 @@ function gradient!(::ForwardDiffAD, g, f, x)
 end
 jacobian(::ForwardDiffAD, f, x) = ForwardDiff.jacobian(f, x)
 hessian(::ForwardDiffAD, f, x) = ForwardDiff.hessian(f, x)
-function directional_derivative(::ForwardDiffAD, f, x, v)
+function pushforward(::ForwardDiffAD, f, x, v)
     return ForwardDiff.derivative(t -> f(x + t * v), 0)
 end
 function pullback(::ForwardDiffAD, f, x, v)
@@ -50,8 +50,8 @@ end
         function hessian(b::ZygoteAD, f, x)
             return jacobian(ForwardDiffAD(), x -> gradient(b, f, x), x)
         end
-        function directional_derivative(::ZygoteAD, f, x, v)
-            return Zygote.jacobian(t -> f(x + t * v), 0)[1]
+        function pushforward(::ZygoteAD, f, x, v)
+            return vec(Zygote.jacobian(t -> f(x + t * v), 0)[1])
         end
         function pullback(::ZygoteAD, f, x, v)
             g = Zygote.gradient(x -> dot(f(x), v), x)[1]
@@ -65,8 +65,8 @@ end
         end
         jacobian(::ReverseDiffAD, f, x) = ReverseDiff.jacobian(f, x)
         hessian(::ReverseDiffAD, f, x) = ReverseDiff.hessian(f, x)
-        function directional_derivative(::ReverseDiffAD, f, x, v)
-            return ReverseDiff.gradient(t -> f(x + t[1] * v), [0.0])[1]
+        function pushforward(::ReverseDiffAD, f, x, v)
+            return vec(ReverseDiff.jacobian(t -> f(x + t[1] * v), [0.0]))
         end
         function pullback(::ReverseDiffAD, f, x, v)
             return ReverseDiff.gradient(x -> dot(f(x), v), x)

--- a/src/ad.jl
+++ b/src/ad.jl
@@ -8,7 +8,6 @@ gradient(b::ADBackend, ::Any, ::Any) = throw_error(b)
 gradient!(b::ADBackend, ::Any, ::Any, ::Any) = throw_error(b)
 jacobian(b::ADBackend, ::Any, ::Any) = throw_error(b)
 hessian(b::ADBackend, ::Any, ::Any) = throw_error(b)
-pushforward(b::ADBackend, ::Any, ::Any, ::Any) = throw_error(b)
 pullback(b::ADBackend, ::Any, ::Any, ::Any) = throw_error(b)
 # Use FD for these always
 function directional_derivative(::ADBackend, f, x, v)
@@ -31,11 +30,6 @@ function gradient!(::ForwardDiffAD, g, f, x)
 end
 jacobian(::ForwardDiffAD, f, x) = ForwardDiff.jacobian(f, x)
 hessian(::ForwardDiffAD, f, x) = ForwardDiff.hessian(f, x)
-function pushforward(::ForwardDiffAD, f, x, v)
-    return ForwardDiff.derivative(
-        t -> ForwardDiff.gradient(f, x + t * v), 0,
-    )
-end
 function pullback(::ForwardDiffAD, f, x, v)
     return ForwardDiff.gradient(x -> dot(f(x), v), x)
 end
@@ -46,11 +40,6 @@ end
         gradient!(::ZygoteAD, g, f, x) = g .= Zygote.gradient(f, x)[1]
         jacobian(::ZygoteAD, f, x) = Zygote.jacobian(f, x)[1]
         hessian(::ZygoteAD, f, x) = Zygote.hessian(f, x)
-        function pushforward(::ZygoteAD, f, x, v)
-            return ForwardDiff.derivative(
-                t -> Zygote.gradient(f, x + t * v), 0,
-            )
-        end
         function pullback(::ZygoteAD, f, x, v)
             return Zygote.gradient(x -> dot(f(x), v), x)[1]
         end
@@ -62,11 +51,6 @@ end
         end
         jacobian(::ReverseDiffAD, f, x) = ReverseDiff.jacobian(f, x)
         hessian(::ReverseDiffAD, f, x) = ReverseDiff.hessian(f, x)
-        function pushforward(::ReverseDiffAD, f, x, v)
-            return ForwardDiff.derivative(
-                t -> ReverseDiff.gradient(f, x + t * v), 0,
-            )
-        end
         function pullback(::ReverseDiffAD, f, x, v)
             return ReverseDiff.gradient(x -> dot(f(x), v), x)
         end

--- a/src/ad.jl
+++ b/src/ad.jl
@@ -66,7 +66,7 @@ end
         jacobian(::ReverseDiffAD, f, x) = ReverseDiff.jacobian(f, x)
         hessian(::ReverseDiffAD, f, x) = ReverseDiff.hessian(f, x)
         function directional_derivative(::ReverseDiffAD, f, x, v)
-            return ReverseDiff.derivative(t -> f(x + t * v), 0)
+            return ReverseDiff.gradient(t -> f(x + t[1] * v), [0.0])[1]
         end
         function pullback(::ReverseDiffAD, f, x, v)
             return ReverseDiff.gradient(x -> dot(f(x), v), x)

--- a/src/ad.jl
+++ b/src/ad.jl
@@ -8,8 +8,8 @@ gradient(b::ADBackend, ::Any, ::Any) = throw_error(b)
 gradient!(b::ADBackend, ::Any, ::Any, ::Any) = throw_error(b)
 jacobian(b::ADBackend, ::Any, ::Any) = throw_error(b)
 hessian(b::ADBackend, ::Any, ::Any) = throw_error(b)
-pushforward(b::ADBackend, ::Any, ::Any, ::Any) = throw_error(b)
-pullback(b::ADBackend, ::Any, ::Any, ::Any) = throw_error(b)
+Jprod(b::ADBackend, ::Any, ::Any, ::Any) = throw_error(b)
+Jtprod(b::ADBackend, ::Any, ::Any, ::Any) = throw_error(b)
 function directional_second_derivative(::ADBackend, f, x, v, w)
     return ForwardDiff.derivative(
         t -> ForwardDiff.derivative(
@@ -27,10 +27,10 @@ function gradient!(::ForwardDiffAD, g, f, x)
 end
 jacobian(::ForwardDiffAD, f, x) = ForwardDiff.jacobian(f, x)
 hessian(::ForwardDiffAD, f, x) = ForwardDiff.hessian(f, x)
-function pushforward(::ForwardDiffAD, f, x, v)
+function Jprod(::ForwardDiffAD, f, x, v)
     return ForwardDiff.derivative(t -> f(x + t * v), 0)
 end
-function pullback(::ForwardDiffAD, f, x, v)
+function Jtprod(::ForwardDiffAD, f, x, v)
     return ForwardDiff.gradient(x -> dot(f(x), v), x)
 end
 
@@ -50,10 +50,10 @@ end
         function hessian(b::ZygoteAD, f, x)
             return jacobian(ForwardDiffAD(), x -> gradient(b, f, x), x)
         end
-        function pushforward(::ZygoteAD, f, x, v)
+        function Jprod(::ZygoteAD, f, x, v)
             return vec(Zygote.jacobian(t -> f(x + t * v), 0)[1])
         end
-        function pullback(::ZygoteAD, f, x, v)
+        function Jtprod(::ZygoteAD, f, x, v)
             g = Zygote.gradient(x -> dot(f(x), v), x)[1]
             return g === nothing ? zero(x) : g
         end
@@ -65,10 +65,10 @@ end
         end
         jacobian(::ReverseDiffAD, f, x) = ReverseDiff.jacobian(f, x)
         hessian(::ReverseDiffAD, f, x) = ReverseDiff.hessian(f, x)
-        function pushforward(::ReverseDiffAD, f, x, v)
+        function Jprod(::ReverseDiffAD, f, x, v)
             return vec(ReverseDiff.jacobian(t -> f(x + t[1] * v), [0.0]))
         end
-        function pullback(::ReverseDiffAD, f, x, v)
+        function Jtprod(::ReverseDiffAD, f, x, v)
             return ReverseDiff.gradient(x -> dot(f(x), v), x)
         end
     end

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -224,7 +224,7 @@ function NLPModels.hprod!(nlp :: ADNLPModel, x :: AbstractVector, v :: AbstractV
   @lencheck n x v Hv
   increment!(nlp, :neval_hprod)
   ℓ(x) = obj_weight * nlp.f(x)
-  Hv .= hprod(nlp.adbackend, ℓ, x, v)
+  Hv .= Hvprod(nlp.adbackend, ℓ, x, v)
   return Hv
 end
 
@@ -234,7 +234,7 @@ function NLPModels.hprod!(nlp :: ADNLPModel, x :: AbstractVector, y :: AbstractV
   @lencheck nlp.meta.ncon y
   increment!(nlp, :neval_hprod)
   ℓ(x) = obj_weight * nlp.f(x) + dot(nlp.c(x), y)
-  Hv .= hprod(nlp.adbackend, ℓ, x, v)
+  Hv .= Hvprod(nlp.adbackend, ℓ, x, v)
   return Hv
 end
 

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -148,7 +148,7 @@ function NLPModels.jprod!(nlp :: ADNLPModel, x :: AbstractVector, v :: AbstractV
   @lencheck nlp.meta.nvar x v
   @lencheck nlp.meta.ncon Jv
   increment!(nlp, :neval_jprod)
-  Jv .= pushforward(nlp.adbackend, nlp.c, x, v)
+  Jv .= Jprod(nlp.adbackend, nlp.c, x, v)
   return Jv
 end
 
@@ -156,7 +156,7 @@ function NLPModels.jtprod!(nlp :: ADNLPModel, x :: AbstractVector, v :: Abstract
   @lencheck nlp.meta.nvar x Jtv
   @lencheck nlp.meta.ncon v
   increment!(nlp, :neval_jtprod)
-  Jtv .= pullback(nlp.adbackend, nlp.c, x, v)
+  Jtv .= Jtprod(nlp.adbackend, nlp.c, x, v)
   return Jtv
 end
 

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -224,7 +224,7 @@ function NLPModels.hprod!(nlp :: ADNLPModel, x :: AbstractVector, v :: AbstractV
   @lencheck n x v Hv
   increment!(nlp, :neval_hprod)
   ℓ(x) = obj_weight * nlp.f(x)
-  Hv .= pushforward(nlp.adbackend, ℓ, x, v)
+  Hv .= hprod(nlp.adbackend, ℓ, x, v)
   return Hv
 end
 
@@ -234,7 +234,7 @@ function NLPModels.hprod!(nlp :: ADNLPModel, x :: AbstractVector, y :: AbstractV
   @lencheck nlp.meta.ncon y
   increment!(nlp, :neval_hprod)
   ℓ(x) = obj_weight * nlp.f(x) + dot(nlp.c(x), y)
-  Hv .= pushforward(nlp.adbackend, ℓ, x, v)
+  Hv .= hprod(nlp.adbackend, ℓ, x, v)
   return Hv
 end
 

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -148,7 +148,7 @@ function NLPModels.jprod!(nlp :: ADNLPModel, x :: AbstractVector, v :: AbstractV
   @lencheck nlp.meta.nvar x v
   @lencheck nlp.meta.ncon Jv
   increment!(nlp, :neval_jprod)
-  Jv .= directional_derivative(nlp.adbackend, nlp.c, x, v)
+  Jv .= pushforward(nlp.adbackend, nlp.c, x, v)
   return Jv
 end
 

--- a/src/nls.jl
+++ b/src/nls.jl
@@ -165,7 +165,7 @@ function NLPModels.hess_residual(nls :: ADNLSModel, x :: AbstractVector, v :: Ab
   @lencheck nls.meta.nvar x
   @lencheck nls.nls_meta.nequ v
   increment!(nls, :neval_hess_residual)
-  return tril(jacobian(nls.adbackend, x -> pullback(nls.adbackend, nls.F, x, v), x))
+  return tril(hessian(nls.adbackend, x -> dot(nls.F(x), v), x))
 end
 
 function NLPModels.hess_structure_residual!(nls :: ADNLSModel, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer})
@@ -182,7 +182,7 @@ function NLPModels.hess_coord_residual!(nls :: ADNLSModel, x :: AbstractVector, 
   @lencheck nls.nls_meta.nequ v
   @lencheck nls.nls_meta.nnzh vals
   increment!(nls, :neval_hess_residual)
-  Hx = jacobian(nls.adbackend, x -> pullback(nls.adbackend, nls.F, x, v), x)
+  Hx = hessian(nls.adbackend, x -> dot(nls.F(x), v), x)
   k = 1
   for j = 1:nls.meta.nvar
     for i = j:nls.meta.nvar

--- a/src/nls.jl
+++ b/src/nls.jl
@@ -165,7 +165,8 @@ function NLPModels.hess_residual(nls :: ADNLSModel, x :: AbstractVector, v :: Ab
   @lencheck nls.meta.nvar x
   @lencheck nls.nls_meta.nequ v
   increment!(nls, :neval_hess_residual)
-  return tril(hessian(nls.adbackend, x -> dot(nls.F(x), v), x))
+  ϕ(x) = dot(nls.F(x), v)
+  return tril(hessian(nls.adbackend, ϕ, x))
 end
 
 function NLPModels.hess_structure_residual!(nls :: ADNLSModel, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer})

--- a/src/nls.jl
+++ b/src/nls.jl
@@ -149,7 +149,7 @@ function NLPModels.jprod_residual!(nls :: ADNLSModel, x :: AbstractVector, v :: 
   @lencheck nls.meta.nvar x v
   @lencheck nls.nls_meta.nequ Jv
   increment!(nls, :neval_jprod_residual)
-  Jv .= pushforward(nls.adbackend, nls.F, x, v)
+  Jv .= Jprod(nls.adbackend, nls.F, x, v)
   return Jv
 end
 
@@ -157,7 +157,7 @@ function NLPModels.jtprod_residual!(nls :: ADNLSModel, x :: AbstractVector, v ::
   @lencheck nls.meta.nvar x Jtv
   @lencheck nls.nls_meta.nequ v
   increment!(nls, :neval_jtprod_residual)
-  Jtv .= pullback(nls.adbackend, nls.F, x, v)
+  Jtv .= Jtprod(nls.adbackend, nls.F, x, v)
   return Jtv
 end
 
@@ -242,7 +242,7 @@ function NLPModels.jprod!(nls :: ADNLSModel, x :: AbstractVector, v :: AbstractV
   @lencheck nls.meta.nvar x v
   @lencheck nls.meta.ncon Jv
   increment!(nls, :neval_jprod)
-  Jv .= pushforward(nls.adbackend, nls.c, x, v)
+  Jv .= Jprod(nls.adbackend, nls.c, x, v)
   return Jv
 end
 
@@ -250,7 +250,7 @@ function NLPModels.jtprod!(nls :: ADNLSModel, x :: AbstractVector, v :: Abstract
   @lencheck nls.meta.nvar x Jtv
   @lencheck nls.meta.ncon v
   increment!(nls, :neval_jtprod)
-  Jtv .= pullback(nls.adbackend, nls.c, x, v)
+  Jtv .= Jtprod(nls.adbackend, nls.c, x, v)
   return Jtv
 end
 

--- a/src/nls.jl
+++ b/src/nls.jl
@@ -4,13 +4,14 @@ mutable struct ADNLSModel <: AbstractNLSModel
   meta :: NLPModelMeta
   nls_meta :: NLSMeta
   counters :: NLSCounters
+  adbackend :: ADBackend
 
   # Function
   F
   c
 end
 
-ADNLPModels.show_header(io :: IO, nls :: ADNLSModel) = println(io, "ADNLSModel - Nonlinear least-squares model with automatic differentiation")
+ADNLPModels.show_header(io :: IO, nls :: ADNLSModel) = println(io, "ADNLSModel - Nonlinear least-squares model with automatic differentiation backend $(nls.adbackend)")
 
 """
     ADNLSModel(F, x0, nequ)
@@ -38,7 +39,7 @@ The following keyword arguments are available to the constructors for constraine
 """
 function ADNLSModel(F, x0 :: AbstractVector{T}, nequ :: Integer;
                     linequ :: AbstractVector{<: Integer} = Int[],
-                    name :: String = "Generic",
+                    name :: String = "Generic", adbackend = ForwardDiffAD(),
                    ) where T
 
   nvar = length(x0)
@@ -47,13 +48,13 @@ function ADNLSModel(F, x0 :: AbstractVector{T}, nequ :: Integer;
   nlnequ = setdiff(1:nequ, linequ)
   nls_meta = NLSMeta(nequ, nvar, nnzj=nequ * nvar, nnzh=div(nvar * (nvar + 1), 2), lin=linequ, nln=nlnequ)
 
-  return ADNLSModel(meta, nls_meta, NLSCounters(), F, x->T[])
+  return ADNLSModel(meta, nls_meta, NLSCounters(), adbackend, F, x->T[])
 end
 
 function ADNLSModel(F, x0 :: AbstractVector{T}, nequ :: Integer,
                     lvar :: AbstractVector, uvar :: AbstractVector;
                     linequ :: AbstractVector{<: Integer} = Int[],
-                    name :: String = "Generic",
+                    name :: String = "Generic", adbackend = ForwardDiffAD(),
                    ) where T
 
   nvar = length(x0)
@@ -63,7 +64,7 @@ function ADNLSModel(F, x0 :: AbstractVector{T}, nequ :: Integer,
   nlnequ = setdiff(1:nequ, linequ)
   nls_meta = NLSMeta(nequ, nvar, nnzj=nequ * nvar, nnzh=div(nvar * (nvar + 1), 2), lin=linequ, nln=nlnequ)
 
-  return ADNLSModel(meta, nls_meta, NLSCounters(), F, x->T[])
+  return ADNLSModel(meta, nls_meta, NLSCounters(), adbackend, F, x->T[])
 end
 
 function ADNLSModel(F, x0 :: AbstractVector{T}, nequ :: Integer,
@@ -71,7 +72,7 @@ function ADNLSModel(F, x0 :: AbstractVector{T}, nequ :: Integer,
                     y0 :: AbstractVector = fill!(similar(lcon), zero(T)),
                     lin :: AbstractVector{<: Integer} = Int[],
                     linequ :: AbstractVector{<: Integer} = Int[],
-                    name :: String = "Generic",
+                    name :: String = "Generic", adbackend = ForwardDiffAD(),
                    ) where T
 
   nvar = length(x0)
@@ -85,7 +86,7 @@ function ADNLSModel(F, x0 :: AbstractVector{T}, nequ :: Integer,
   nlnequ = setdiff(1:nequ, linequ)
   nls_meta = NLSMeta(nequ, nvar, nnzj=nequ * nvar, nnzh=div(nvar * (nvar + 1), 2), lin=linequ, nln=nlnequ)
 
-  return ADNLSModel(meta, nls_meta, NLSCounters(), F, c)
+  return ADNLSModel(meta, nls_meta, NLSCounters(), adbackend, F, c)
 end
 
 function ADNLSModel(F, x0 :: AbstractVector{T}, nequ :: Integer,
@@ -94,7 +95,7 @@ function ADNLSModel(F, x0 :: AbstractVector{T}, nequ :: Integer,
                     y0 :: AbstractVector = fill!(similar(lcon), zero(T)),
                     lin :: AbstractVector{<: Integer} = Int[],
                     linequ :: AbstractVector{<: Integer} = Int[],
-                    name :: String = "Generic",
+                    name :: String = "Generic", adbackend = ForwardDiffAD(),
                    ) where T
 
   nvar = length(x0)
@@ -109,7 +110,7 @@ function ADNLSModel(F, x0 :: AbstractVector{T}, nequ :: Integer,
   nlnequ = setdiff(1:nequ, linequ)
   nls_meta = NLSMeta(nequ, nvar, nnzj=nequ * nvar, nnzh=div(nvar * (nvar + 1), 2), lin=linequ, nln=nlnequ)
 
-  return ADNLSModel(meta, nls_meta, NLSCounters(), F, c)
+  return ADNLSModel(meta, nls_meta, NLSCounters(), adbackend, F, c)
 end
 
 function NLPModels.residual!(nls :: ADNLSModel, x :: AbstractVector, Fx :: AbstractVector)
@@ -123,7 +124,7 @@ end
 function NLPModels.jac_residual(nls :: ADNLSModel, x :: AbstractVector)
   @lencheck nls.meta.nvar x
   increment!(nls, :neval_jac_residual)
-  return ForwardDiff.jacobian(nls.F, x)
+  return jacobian(nls.adbackend, nls.F, x)
 end
 
 function NLPModels.jac_structure_residual!(nls :: ADNLSModel, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer})
@@ -139,7 +140,7 @@ function NLPModels.jac_coord_residual!(nls :: ADNLSModel, x :: AbstractVector, v
   @lencheck nls.meta.nvar x
   @lencheck nls.nls_meta.nnzj vals
   increment!(nls, :neval_jac_residual)
-  Jx = ForwardDiff.jacobian(nls.F, x)
+  Jx = jacobian(nls.adbackend, nls.F, x)
   vals .= Jx[:]
   return vals
 end
@@ -148,7 +149,7 @@ function NLPModels.jprod_residual!(nls :: ADNLSModel, x :: AbstractVector, v :: 
   @lencheck nls.meta.nvar x v
   @lencheck nls.nls_meta.nequ Jv
   increment!(nls, :neval_jprod_residual)
-  Jv .= ForwardDiff.derivative(t -> nls.F(x + t * v), 0)
+  Jv .= directional_derivative(nls.adbackend, nls.F, x, v)
   return Jv
 end
 
@@ -156,7 +157,7 @@ function NLPModels.jtprod_residual!(nls :: ADNLSModel, x :: AbstractVector, v ::
   @lencheck nls.meta.nvar x Jtv
   @lencheck nls.nls_meta.nequ v
   increment!(nls, :neval_jtprod_residual)
-  Jtv .= ForwardDiff.gradient(x -> dot(nls.F(x), v), x)
+  Jtv .= pullback(nls.adbackend, nls.F, x, v)
   return Jtv
 end
 
@@ -164,7 +165,7 @@ function NLPModels.hess_residual(nls :: ADNLSModel, x :: AbstractVector, v :: Ab
   @lencheck nls.meta.nvar x
   @lencheck nls.nls_meta.nequ v
   increment!(nls, :neval_hess_residual)
-  return tril(ForwardDiff.jacobian(x -> ForwardDiff.jacobian(nls.F, x)' * v, x))
+  return tril(jacobian(nls.adbackend, x -> pullback(nls.adbackend, nls.F, x, v), x))
 end
 
 function NLPModels.hess_structure_residual!(nls :: ADNLSModel, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer})
@@ -181,7 +182,7 @@ function NLPModels.hess_coord_residual!(nls :: ADNLSModel, x :: AbstractVector, 
   @lencheck nls.nls_meta.nequ v
   @lencheck nls.nls_meta.nnzh vals
   increment!(nls, :neval_hess_residual)
-  Hx = ForwardDiff.jacobian(x->ForwardDiff.jacobian(nls.F, x)' * v, x)
+  Hx = jacobian(nls.adbackend, x -> pullback(nls.adbackend, nls.F, x, v), x)
   k = 1
   for j = 1:nls.meta.nvar
     for i = j:nls.meta.nvar
@@ -195,13 +196,13 @@ end
 function NLPModels.jth_hess_residual(nls :: ADNLSModel, x :: AbstractVector, i :: Int)
   @lencheck nls.meta.nvar x
   increment!(nls, :neval_jhess_residual)
-  return tril(ForwardDiff.hessian(x->nls.F(x)[i], x))
+  return tril(hessian(nls.adbackend, x -> nls.F(x)[i], x))
 end
 
 function NLPModels.hprod_residual!(nls :: ADNLSModel, x :: AbstractVector, i :: Int, v :: AbstractVector, Hiv :: AbstractVector)
   @lencheck nls.meta.nvar x v Hiv
   increment!(nls, :neval_hprod_residual)
-  Hiv .= ForwardDiff.derivative(t -> ForwardDiff.gradient(x -> nls.F(x)[i], x + t * v), 0)
+  Hiv .= hvprod(nls.adbackend, x -> nls.F(x)[i], x, v)
   return Hiv
 end
 
@@ -216,7 +217,7 @@ end
 function NLPModels.jac(nls :: ADNLSModel, x :: AbstractVector)
   @lencheck nls.meta.nvar x
   increment!(nls, :neval_jac)
-  return ForwardDiff.jacobian(nls.c, x)
+  return jacobian(nls.adbackend, nls.c, x)
 end
 
 function NLPModels.jac_structure!(nls :: ADNLSModel, rows :: AbstractVector{<: Integer}, cols :: AbstractVector{<: Integer})
@@ -231,7 +232,7 @@ end
 function NLPModels.jac_coord!(nls :: ADNLSModel, x :: AbstractVector, vals :: AbstractVector)
   @lencheck nls.meta.nvar x
   @lencheck nls.meta.nnzj vals
-  Jx = ForwardDiff.jacobian(nls.c, x)
+  Jx = jacobian(nls.adbackend, nls.c, x)
   vals .= Jx[:]
   return vals
 end
@@ -240,7 +241,7 @@ function NLPModels.jprod!(nls :: ADNLSModel, x :: AbstractVector, v :: AbstractV
   @lencheck nls.meta.nvar x v
   @lencheck nls.meta.ncon Jv
   increment!(nls, :neval_jprod)
-  Jv .= ForwardDiff.derivative(t -> nls.c(x + t * v), 0)
+  Jv .= directional_derivative(t -> nls.c(x + t * v), 0)
   return Jv
 end
 
@@ -248,7 +249,7 @@ function NLPModels.jtprod!(nls :: ADNLSModel, x :: AbstractVector, v :: Abstract
   @lencheck nls.meta.nvar x Jtv
   @lencheck nls.meta.ncon v
   increment!(nls, :neval_jtprod)
-  Jtv .= ForwardDiff.gradient(x -> dot(nls.c(x), v), x)
+  Jtv .= pullback(nls.adbackend, nls.c, x, v)
   return Jtv
 end
 
@@ -256,7 +257,7 @@ function NLPModels.hess(nls :: ADNLSModel, x :: AbstractVector; obj_weight :: Re
   @lencheck nls.meta.nvar x
   increment!(nls, :neval_hess)
   ℓ(x) = obj_weight * sum(nls.F(x).^2) / 2
-  Hx = ForwardDiff.hessian(ℓ, x)
+  Hx = hessian(nls.adbackend, ℓ, x)
   return tril(Hx)
 end
 
@@ -265,7 +266,7 @@ function NLPModels.hess(nls :: ADNLSModel, x :: AbstractVector, y :: AbstractVec
   @lencheck nls.meta.ncon y
   increment!(nls, :neval_hess)
   ℓ(x) = obj_weight * sum(nls.F(x).^2) / 2 + dot(y, nls.c(x))
-  Hx = ForwardDiff.hessian(ℓ, x)
+  Hx = hessian(nls.adbackend, ℓ, x)
   return tril(Hx)
 end
 
@@ -283,7 +284,7 @@ function NLPModels.hess_coord!(nls :: ADNLSModel, x :: AbstractVector, vals :: A
   @lencheck nls.meta.nnzh vals
   increment!(nls, :neval_hess)
   ℓ(x) = obj_weight * sum(nls.F(x).^2) / 2
-  Hx = ForwardDiff.hessian(ℓ, x)
+  Hx = hessian(nls.adbackend, ℓ, x)
   k = 1
   for j = 1:nls.meta.nvar
     for i = j:nls.meta.nvar
@@ -300,7 +301,7 @@ function NLPModels.hess_coord!(nls :: ADNLSModel, x :: AbstractVector, y :: Abst
   @lencheck nls.meta.nnzh vals
   increment!(nls, :neval_hess)
   ℓ(x) = obj_weight * sum(nls.F(x).^2) / 2 + dot(y, nls.c(x))
-  Hx = ForwardDiff.hessian(ℓ, x)
+  Hx = hessian(nls.adbackend, ℓ, x)
   k = 1
   for j = 1:nls.meta.nvar
     for i = j:nls.meta.nvar
@@ -315,7 +316,7 @@ function NLPModels.hprod!(nls :: ADNLSModel, x :: AbstractVector, v :: AbstractV
   @lencheck nls.meta.nvar x v Hv
   increment!(nls, :neval_hprod)
   ℓ(x) = obj_weight * sum(nls.F(x).^2) / 2
-  Hv .= ForwardDiff.derivative(t -> ForwardDiff.gradient(ℓ, x + t * v), 0)
+  Hv .= hvprod(nls.adbackend, ℓ, x, v)
   return Hv
 end
 
@@ -325,7 +326,7 @@ function NLPModels.hprod!(nls :: ADNLSModel, x :: AbstractVector, y :: AbstractV
   @lencheck nls.meta.ncon y
   increment!(nls, :neval_hprod)
   ℓ(x) = obj_weight * sum(nls.F(x).^2) / 2 + dot(y, nls.c(x))
-  Hv .= ForwardDiff.derivative(t -> ForwardDiff.gradient(ℓ, x + t * v), 0)
+  Hv .= hvprod(nls.adbackend, ℓ, x, v)
   return Hv
 end
 
@@ -333,6 +334,6 @@ function NLPModels.ghjvprod!(nls :: ADNLSModel, x :: AbstractVector, g :: Abstra
   @lencheck nls.meta.nvar x g v
   @lencheck nls.meta.ncon gHv
   increment!(nls, :neval_hprod)
-  gHv .= ForwardDiff.derivative(t -> ForwardDiff.derivative(s -> nls.c(x + s * g + t * v), 0), 0)
+  gHv .= directional_second_derivative(nls.adbackend, nls.c, x, v, g)
   return gHv
 end

--- a/src/nls.jl
+++ b/src/nls.jl
@@ -202,7 +202,7 @@ end
 function NLPModels.hprod_residual!(nls :: ADNLSModel, x :: AbstractVector, i :: Int, v :: AbstractVector, Hiv :: AbstractVector)
   @lencheck nls.meta.nvar x v Hiv
   increment!(nls, :neval_hprod_residual)
-  Hiv .= hvprod(nls.adbackend, x -> nls.F(x)[i], x, v)
+  Hiv .= Hvprod(nls.adbackend, x -> nls.F(x)[i], x, v)
   return Hiv
 end
 
@@ -316,7 +316,7 @@ function NLPModels.hprod!(nls :: ADNLSModel, x :: AbstractVector, v :: AbstractV
   @lencheck nls.meta.nvar x v Hv
   increment!(nls, :neval_hprod)
   ℓ(x) = obj_weight * sum(nls.F(x).^2) / 2
-  Hv .= hvprod(nls.adbackend, ℓ, x, v)
+  Hv .= Hvprod(nls.adbackend, ℓ, x, v)
   return Hv
 end
 
@@ -326,7 +326,7 @@ function NLPModels.hprod!(nls :: ADNLSModel, x :: AbstractVector, y :: AbstractV
   @lencheck nls.meta.ncon y
   increment!(nls, :neval_hprod)
   ℓ(x) = obj_weight * sum(nls.F(x).^2) / 2 + dot(y, nls.c(x))
-  Hv .= hvprod(nls.adbackend, ℓ, x, v)
+  Hv .= Hvprod(nls.adbackend, ℓ, x, v)
   return Hv
 end
 

--- a/src/nls.jl
+++ b/src/nls.jl
@@ -149,7 +149,7 @@ function NLPModels.jprod_residual!(nls :: ADNLSModel, x :: AbstractVector, v :: 
   @lencheck nls.meta.nvar x v
   @lencheck nls.nls_meta.nequ Jv
   increment!(nls, :neval_jprod_residual)
-  Jv .= directional_derivative(nls.adbackend, nls.F, x, v)
+  Jv .= pushforward(nls.adbackend, nls.F, x, v)
   return Jv
 end
 
@@ -241,7 +241,7 @@ function NLPModels.jprod!(nls :: ADNLSModel, x :: AbstractVector, v :: AbstractV
   @lencheck nls.meta.nvar x v
   @lencheck nls.meta.ncon Jv
   increment!(nls, :neval_jprod)
-  Jv .= directional_derivative(nls.adbackend, nls.c, x, v)
+  Jv .= pushforward(nls.adbackend, nls.c, x, v)
   return Jv
 end
 

--- a/src/nls.jl
+++ b/src/nls.jl
@@ -241,7 +241,7 @@ function NLPModels.jprod!(nls :: ADNLSModel, x :: AbstractVector, v :: AbstractV
   @lencheck nls.meta.nvar x v
   @lencheck nls.meta.ncon Jv
   increment!(nls, :neval_jprod)
-  Jv .= directional_derivative(t -> nls.c(x + t * v), 0)
+  Jv .= directional_derivative(nls.adbackend, nls.c, x, v)
   return Jv
 end
 

--- a/test/nlp/basic.jl
+++ b/test/nlp/basic.jl
@@ -9,41 +9,45 @@ function (regr::LinearRegression)(beta)
 end
 
 function test_autodiff_model()
-  x0 = zeros(2)
-  f(x) = dot(x,x)
-  nlp = ADNLPModel(f, x0)
+  for adbackend in [
+    ForwardDiffAD(), ZygoteAD(), ReverseDiffAD(),
+  ]
+    x0 = zeros(2)
+    f(x) = dot(x,x)
+    nlp = ADNLPModel(f, x0, adbackend = adbackend)
 
-  c(x) = [sum(x) - 1]
-  nlp = ADNLPModel(f, x0, c, [0], [0])
-  @test obj(nlp, x0) == f(x0)
+    c(x) = [sum(x) - 1]
+    nlp = ADNLPModel(f, x0, c, [0], [0], adbackend = adbackend)
+    @test obj(nlp, x0) == f(x0)
 
-  x = range(-1, stop=1, length=100)
-  y = 2x .+ 3 + randn(100) * 0.1
-  regr = LinearRegression(x, y)
-  nlp = ADNLPModel(regr, ones(2))
-  β = [ones(100) x] \ y
-  @test abs(obj(nlp, β) - norm(y .- β[1] - β[2] * x)^2 / 2) < 1e-12
-  @test norm(grad(nlp, β)) < 1e-12
+    x = range(-1, stop=1, length=100)
+    y = 2x .+ 3 + randn(100) * 0.1
+    regr = LinearRegression(x, y)
+    nlp = ADNLPModel(regr, ones(2), adbackend = adbackend)
+    β = [ones(100) x] \ y
+    @test abs(obj(nlp, β) - norm(y .- β[1] - β[2] * x)^2 / 2) < 1e-12
+    @test norm(grad(nlp, β)) < 1e-12
 
-  @testset "Constructors for ADNLPModel" begin
-    lvar, uvar, lcon, ucon, y0 = -ones(2), ones(2), -ones(1), ones(1), zeros(1)
-    badlvar, baduvar, badlcon, baducon, bady0 = -ones(3), ones(3), -ones(2), ones(2), zeros(2)
-    nlp = ADNLPModel(f, x0)
-    nlp = ADNLPModel(f, x0, lvar, uvar)
-    nlp = ADNLPModel(f, x0, c, lcon, ucon)
-    nlp = ADNLPModel(f, x0, c, lcon, ucon, y0=y0)
-    nlp = ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon)
-    nlp = ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, y0=y0)
-    @test_throws DimensionError ADNLPModel(f, x0, badlvar, uvar)
-    @test_throws DimensionError ADNLPModel(f, x0, lvar, baduvar)
-    @test_throws DimensionError ADNLPModel(f, x0, c, badlcon, ucon)
-    @test_throws DimensionError ADNLPModel(f, x0, c, lcon, baducon)
-    @test_throws DimensionError ADNLPModel(f, x0, c, lcon, ucon, y0=bady0)
-    @test_throws DimensionError ADNLPModel(f, x0, badlvar, uvar, c, lcon, ucon)
-    @test_throws DimensionError ADNLPModel(f, x0, lvar, baduvar, c, lcon, ucon)
-    @test_throws DimensionError ADNLPModel(f, x0, lvar, uvar, c, badlcon, ucon)
-    @test_throws DimensionError ADNLPModel(f, x0, lvar, uvar, c, lcon, baducon)
-    @test_throws DimensionError ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, y0=bady0)
+    @testset "Constructors for ADNLPModel" begin
+      lvar, uvar, lcon, ucon, y0 = -ones(2), ones(2), -ones(1), ones(1), zeros(1)
+      badlvar, baduvar, badlcon, baducon, bady0 = -ones(3), ones(3), -ones(2), ones(2), zeros(2)
+      nlp = ADNLPModel(f, x0, adbackend = adbackend)
+      nlp = ADNLPModel(f, x0, lvar, uvar, adbackend = adbackend)
+      nlp = ADNLPModel(f, x0, c, lcon, ucon, adbackend = adbackend)
+      nlp = ADNLPModel(f, x0, c, lcon, ucon, y0=y0, adbackend = adbackend)
+      nlp = ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, adbackend = adbackend)
+      nlp = ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, y0=y0, adbackend = adbackend)
+      @test_throws DimensionError ADNLPModel(f, x0, badlvar, uvar, adbackend = adbackend)
+      @test_throws DimensionError ADNLPModel(f, x0, lvar, baduvar, adbackend = adbackend)
+      @test_throws DimensionError ADNLPModel(f, x0, c, badlcon, ucon, adbackend = adbackend)
+      @test_throws DimensionError ADNLPModel(f, x0, c, lcon, baducon, adbackend = adbackend)
+      @test_throws DimensionError ADNLPModel(f, x0, c, lcon, ucon, y0=bady0, adbackend = adbackend)
+      @test_throws DimensionError ADNLPModel(f, x0, badlvar, uvar, c, lcon, ucon, adbackend = adbackend)
+      @test_throws DimensionError ADNLPModel(f, x0, lvar, baduvar, c, lcon, ucon, adbackend = adbackend)
+      @test_throws DimensionError ADNLPModel(f, x0, lvar, uvar, c, badlcon, ucon, adbackend = adbackend)
+      @test_throws DimensionError ADNLPModel(f, x0, lvar, uvar, c, lcon, baducon, adbackend = adbackend)
+      @test_throws DimensionError ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, y0=bady0, adbackend = adbackend)
+    end
   end
 end
 

--- a/test/nlp/basic.jl
+++ b/test/nlp/basic.jl
@@ -8,6 +8,20 @@ function (regr::LinearRegression)(beta)
   return dot(r, r) / 2
 end
 
+function test_autodiff_backend_error()
+  @testset "Error without loading package - $adbackend" for adbackend in [
+    ZygoteAD(), ReverseDiffAD(),
+  ]
+    @test_throws ArgumentError gradient(adbackend, sum, [1.0])
+    @test_throws ArgumentError gradient!(adbackend, [1.0], sum, [1.0])
+    @test_throws ArgumentError jacobian(adbackend, identity, [1.0])
+    @test_throws ArgumentError hessian(adbackend, sum, [1.0])
+    @test_throws ArgumentError Jprod(adbackend, [1.0], identity, [1.0])
+    @test_throws ArgumentError Jtprod(adbackend, [1.0], identity, [1.0])
+    @test_throws ArgumentError Hvprod(adbackend, sum, [1.0], [1.0])
+  end
+end
+
 function test_autodiff_model()
   for adbackend in [
     ForwardDiffAD(), ZygoteAD(), ReverseDiffAD(),
@@ -50,5 +64,11 @@ function test_autodiff_model()
     end
   end
 end
+
+# Test the argument error without loading the packages
+test_autodiff_backend_error()
+
+# Automatically loads the code for Zygote and ReverseDiff with Requires
+import Zygote, ReverseDiff
 
 test_autodiff_model()

--- a/test/nlp/nlpmodelstest.jl
+++ b/test/nlp/nlpmodelstest.jl
@@ -4,7 +4,7 @@
   for problem in NLPModelsTest.nlp_problems
     @testset "Checking NLPModelsTest tests on problem $problem" begin
       nlp_ad = eval(Meta.parse(lowercase(problem) * "_autodiff"))()
-      nlp_ad = switch_adbackend(nlp_ad, adbackend)
+      nlp_ad.adbackend = adbackend
       nlp_man = eval(Meta.parse(problem))()
 
       show(IOBuffer(), nlp_ad)

--- a/test/nlp/nlpmodelstest.jl
+++ b/test/nlp/nlpmodelstest.jl
@@ -1,25 +1,30 @@
-for problem in NLPModelsTest.nlp_problems
-  @testset "Checking NLPModelsTest tests on problem $problem" begin
-    nlp_ad = eval(Meta.parse(lowercase(problem) * "_autodiff"))()
-    nlp_man = eval(Meta.parse(problem))()
+@testset "AD backend - $(adbackend)" for adbackend in [
+  ForwardDiffAD(), ZygoteAD(), ReverseDiffAD(),
+]
+  for problem in NLPModelsTest.nlp_problems
+    @testset "Checking NLPModelsTest tests on problem $problem" begin
+      nlp_ad = eval(Meta.parse(lowercase(problem) * "_autodiff"))()
+      nlp_ad = switch_adbackend(nlp_ad, adbackend)
+      nlp_man = eval(Meta.parse(problem))()
 
-    show(IOBuffer(), nlp_ad)
+      show(IOBuffer(), nlp_ad)
 
-    nlps = [nlp_ad, nlp_man]
-    @testset "Check Consistency" begin
-      consistent_nlps(nlps)
-    end
-    @testset "Check dimensions" begin
-      check_nlp_dimensions(nlp_ad)
-    end
-    @testset "Check multiple precision" begin
-      multiple_precision_nlp(nlp_ad)
-    end
-    @testset "Check view subarray" begin
-      view_subarray_nlp(nlp_ad)
-    end
-    @testset "Check coordinate memory" begin
-      coord_memory_nlp(nlp_ad)
+      nlps = [nlp_ad, nlp_man]
+      @testset "Check Consistency" begin
+        consistent_nlps(nlps)
+      end
+      @testset "Check dimensions" begin
+        check_nlp_dimensions(nlp_ad)
+      end
+      @testset "Check multiple precision" begin
+        multiple_precision_nlp(nlp_ad)
+      end
+      @testset "Check view subarray" begin
+        view_subarray_nlp(nlp_ad)
+      end
+      @testset "Check coordinate memory" begin
+        coord_memory_nlp(nlp_ad)
+      end
     end
   end
 end

--- a/test/nls/basic.jl
+++ b/test/nls/basic.jl
@@ -2,7 +2,7 @@ function autodiff_nls_test()
   for adbackend in [
     ForwardDiffAD(), ZygoteAD(), ReverseDiffAD(),
   ]
-    @testset "autodiff_nls_test" begin
+    @testset "autodiff_nls_test for $adbackend" begin
       F(x) = [x[1] - 1; x[2] - x[1]^2]
       nls = ADNLSModel(F, zeros(2), 2, adbackend = adbackend)
 

--- a/test/nls/basic.jl
+++ b/test/nls/basic.jl
@@ -1,34 +1,37 @@
 function autodiff_nls_test()
-  @testset "autodiff_nls_test" begin
-    F(x) = [x[1] - 1; x[2] - x[1]^2]
-    nls = ADNLSModel(F, zeros(2), 2)
+  for adbackend in [
+    ForwardDiffAD(), ZygoteAD(), ReverseDiffAD(),
+  ]
+    @testset "autodiff_nls_test" begin
+      F(x) = [x[1] - 1; x[2] - x[1]^2]
+      nls = ADNLSModel(F, zeros(2), 2, adbackend = adbackend)
 
-    @test isapprox(residual(nls, ones(2)), zeros(2), rtol=1e-8)
-  end
+      @test isapprox(residual(nls, ones(2)), zeros(2), rtol=1e-8)
+    end
 
-  @testset "Constructors for ADNLSModel" begin
-    F(x) = [x[1] - 1; x[2] - x[1]^2; x[1] * x[2]]
-    x0 = ones(2)
-    c(x) = [sum(x) - 1]
-    lvar, uvar, lcon, ucon, y0 = -ones(2), ones(2), -ones(1), ones(1), zeros(1)
-    badlvar, baduvar, badlcon, baducon, bady0 = -ones(3), ones(3), -ones(2), ones(2), zeros(2)
-    nlp = ADNLSModel(F, x0, 3)
-    nlp = ADNLSModel(F, x0, 3, lvar, uvar)
-    nlp = ADNLSModel(F, x0, 3, c, lcon, ucon)
-    nlp = ADNLSModel(F, x0, 3, c, lcon, ucon, y0=y0)
-    nlp = ADNLSModel(F, x0, 3, lvar, uvar, c, lcon, ucon)
-    nlp = ADNLSModel(F, x0, 3, lvar, uvar, c, lcon, ucon, y0=y0)
-    @test_throws DimensionError ADNLSModel(F, x0, 3, badlvar, uvar)
-    @test_throws DimensionError ADNLSModel(F, x0, 3, lvar, baduvar)
-    @test_throws DimensionError ADNLSModel(F, x0, 3, c, badlcon, ucon)
-    @test_throws DimensionError ADNLSModel(F, x0, 3, c, lcon, baducon)
-    @test_throws DimensionError ADNLSModel(F, x0, 3, c, lcon, ucon, y0=bady0)
-    @test_throws DimensionError ADNLSModel(F, x0, 3, badlvar, uvar, c, lcon, ucon)
-    @test_throws DimensionError ADNLSModel(F, x0, 3, lvar, baduvar, c, lcon, ucon)
-    @test_throws DimensionError ADNLSModel(F, x0, 3, lvar, uvar, c, badlcon, ucon)
-    @test_throws DimensionError ADNLSModel(F, x0, 3, lvar, uvar, c, lcon, baducon)
-    @test_throws DimensionError ADNLSModel(F, x0, 3, lvar, uvar, c, lcon, ucon, y0=bady0)
-
+    @testset "Constructors for ADNLSModel" begin
+      F(x) = [x[1] - 1; x[2] - x[1]^2; x[1] * x[2]]
+      x0 = ones(2)
+      c(x) = [sum(x) - 1]
+      lvar, uvar, lcon, ucon, y0 = -ones(2), ones(2), -ones(1), ones(1), zeros(1)
+      badlvar, baduvar, badlcon, baducon, bady0 = -ones(3), ones(3), -ones(2), ones(2), zeros(2)
+      nlp = ADNLSModel(F, x0, 3, adbackend = adbackend)
+      nlp = ADNLSModel(F, x0, 3, lvar, uvar, adbackend = adbackend)
+      nlp = ADNLSModel(F, x0, 3, c, lcon, ucon, adbackend = adbackend)
+      nlp = ADNLSModel(F, x0, 3, c, lcon, ucon, y0=y0, adbackend = adbackend)
+      nlp = ADNLSModel(F, x0, 3, lvar, uvar, c, lcon, ucon, adbackend = adbackend)
+      nlp = ADNLSModel(F, x0, 3, lvar, uvar, c, lcon, ucon, y0=y0, adbackend = adbackend)
+      @test_throws DimensionError ADNLSModel(F, x0, 3, badlvar, uvar, adbackend = adbackend)
+      @test_throws DimensionError ADNLSModel(F, x0, 3, lvar, baduvar, adbackend = adbackend)
+      @test_throws DimensionError ADNLSModel(F, x0, 3, c, badlcon, ucon, adbackend = adbackend)
+      @test_throws DimensionError ADNLSModel(F, x0, 3, c, lcon, baducon, adbackend = adbackend)
+      @test_throws DimensionError ADNLSModel(F, x0, 3, c, lcon, ucon, y0=bady0, adbackend = adbackend)
+      @test_throws DimensionError ADNLSModel(F, x0, 3, badlvar, uvar, c, lcon, ucon, adbackend = adbackend)
+      @test_throws DimensionError ADNLSModel(F, x0, 3, lvar, baduvar, c, lcon, ucon, adbackend = adbackend)
+      @test_throws DimensionError ADNLSModel(F, x0, 3, lvar, uvar, c, badlcon, ucon, adbackend = adbackend)
+      @test_throws DimensionError ADNLSModel(F, x0, 3, lvar, uvar, c, lcon, baducon, adbackend = adbackend)
+      @test_throws DimensionError ADNLSModel(F, x0, 3, lvar, uvar, c, lcon, ucon, y0=bady0, adbackend = adbackend)
+    end
   end
 end
 

--- a/test/nls/nlpmodelstest.jl
+++ b/test/nls/nlpmodelstest.jl
@@ -1,33 +1,38 @@
-for problem in NLPModelsTest.nls_problems
-  @testset "Checking NLPModelsTest tests on problem $problem" begin
-    nls_ad = eval(Meta.parse(lowercase(problem) * "_autodiff"))()
-    nls_man = eval(Meta.parse(problem))()
+@testset "AD backend - $(adbackend)" for adbackend in [
+  ForwardDiffAD(), ZygoteAD(), ReverseDiffAD(),
+]
+  for problem in NLPModelsTest.nls_problems
+    @testset "Checking NLPModelsTest tests on problem $problem" begin
+      nls_ad = eval(Meta.parse(lowercase(problem) * "_autodiff"))()
+      nls_ad = switch_adbackend(nls_ad, adbackend)
+      nls_man = eval(Meta.parse(problem))()
 
-    nlss = AbstractNLSModel[nls_ad]
-    # *_special problems are variant definitions of a model
-    spc = "$(problem)_special"
-    if isdefined(NLPModelsTest, Symbol(spc)) || isdefined(Main, Symbol(spc))
-      push!(nlss, eval(Meta.parse(spc))())
-    end
-
-    for nls in nlss
-      show(IOBuffer(), nls)
-    end
-
-    @testset "Check Consistency" begin
-      consistent_nlss([nlss; nls_man])
-    end
-    @testset "Check dimensions" begin
-      check_nls_dimensions.(nlss)
-      check_nlp_dimensions.(nlss, exclude_hess=true)
-    end
-    @testset "Check multiple precision" begin
-      for nls in nlss
-        multiple_precision_nls(nls)
+      nlss = AbstractNLSModel[nls_ad]
+      # *_special problems are variant definitions of a model
+      spc = "$(problem)_special"
+      if isdefined(NLPModelsTest, Symbol(spc)) || isdefined(Main, Symbol(spc))
+        push!(nlss, eval(Meta.parse(spc))())
       end
-    end
-    @testset "Check view subarray" begin
-      view_subarray_nls.(nlss)
+
+      for nls in nlss
+        show(IOBuffer(), nls)
+      end
+
+      @testset "Check Consistency" begin
+        consistent_nlss([nlss; nls_man])
+      end
+      @testset "Check dimensions" begin
+        check_nls_dimensions.(nlss)
+        check_nlp_dimensions.(nlss, exclude_hess=true)
+      end
+      @testset "Check multiple precision" begin
+        for nls in nlss
+          multiple_precision_nls(nls)
+        end
+      end
+      @testset "Check view subarray" begin
+        view_subarray_nls.(nlss)
+      end
     end
   end
 end

--- a/test/nls/nlpmodelstest.jl
+++ b/test/nls/nlpmodelstest.jl
@@ -4,7 +4,7 @@
   for problem in NLPModelsTest.nls_problems
     @testset "Checking NLPModelsTest tests on problem $problem" begin
       nls_ad = eval(Meta.parse(lowercase(problem) * "_autodiff"))()
-      nls_ad = switch_adbackend(nls_ad, adbackend)
+      nls_ad.adbackend = adbackend
       nls_man = eval(Meta.parse(problem))()
 
       nlss = AbstractNLSModel[nls_ad]

--- a/test/nls/nlpmodelstest.jl
+++ b/test/nls/nlpmodelstest.jl
@@ -1,5 +1,5 @@
 @testset "AD backend - $(adbackend)" for adbackend in [
-  ForwardDiffAD(), ZygoteAD(), ReverseDiffAD(),
+  ForwardDiffAD(), ReverseDiffAD(),
 ]
   for problem in NLPModelsTest.nls_problems
     @testset "Checking NLPModelsTest tests on problem $problem" begin

--- a/test/nls/nlpmodelstest.jl
+++ b/test/nls/nlpmodelstest.jl
@@ -1,5 +1,5 @@
 @testset "AD backend - $(adbackend)" for adbackend in [
-  ForwardDiffAD(), ReverseDiffAD(),
+  ForwardDiffAD(), ZygoteAD(), ReverseDiffAD(),
 ]
   for problem in NLPModelsTest.nls_problems
     @testset "Checking NLPModelsTest tests on problem $problem" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,6 @@
 using ADNLPModels, LinearAlgebra, NLPModels, NLPModelsModifiers, NLPModelsTest, Test
+using Zygote, ReverseDiff
+using ADNLPModels: ForwardDiffAD, ZygoteAD, ReverseDiffAD
 
 for problem in NLPModelsTest.nlp_problems ∪ ["GENROSE"]
   include("nlp/problems/$(lowercase(problem)).jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,13 @@ using ADNLPModels, LinearAlgebra, NLPModels, NLPModelsModifiers, NLPModelsTest, 
 using Zygote, ReverseDiff
 using ADNLPModels: ForwardDiffAD, ZygoteAD, ReverseDiffAD
 
+function switch_adbackend(nlp::ADNLPModel, adbackend)
+  ADNLPModel(nlp.meta, nlp.counters, adbackend, nlp.f, nlp.c)
+end
+function switch_adbackend(nlp::ADNLSModel, adbackend)
+  ADNLSModel(nls.meta, nls.nls_meta, nls.counters, adbackend, nls.F, nls.c)
+end
+
 for problem in NLPModelsTest.nlp_problems ∪ ["GENROSE"]
   include("nlp/problems/$(lowercase(problem)).jl")
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,13 +1,7 @@
 using ADNLPModels, LinearAlgebra, NLPModels, NLPModelsModifiers, NLPModelsTest, Test
-using Zygote, ReverseDiff
-using ADNLPModels: ForwardDiffAD, ZygoteAD, ReverseDiffAD
-
-function switch_adbackend(nlp::ADNLPModel, adbackend)
-  ADNLPModel(nlp.meta, nlp.counters, adbackend, nlp.f, nlp.c)
-end
-function switch_adbackend(nls::ADNLSModel, adbackend)
-  ADNLSModel(nls.meta, nls.nls_meta, nls.counters, adbackend, nls.F, nls.c)
-end
+using ADNLPModels:  ForwardDiffAD, ZygoteAD, ReverseDiffAD,
+                    gradient, gradient!, jacobian, hessian, Jprod,
+                    Jtprod, directional_second_derivative, Hvprod
 
 for problem in NLPModelsTest.nlp_problems ∪ ["GENROSE"]
   include("nlp/problems/$(lowercase(problem)).jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ using ADNLPModels: ForwardDiffAD, ZygoteAD, ReverseDiffAD
 function switch_adbackend(nlp::ADNLPModel, adbackend)
   ADNLPModel(nlp.meta, nlp.counters, adbackend, nlp.f, nlp.c)
 end
-function switch_adbackend(nlp::ADNLSModel, adbackend)
+function switch_adbackend(nls::ADNLSModel, adbackend)
   ADNLSModel(nls.meta, nls.nls_meta, nls.counters, adbackend, nls.F, nls.c)
 end
 


### PR DESCRIPTION
This PR enables the use of Zygote or ReverseDiff in ADNLPModel using Requires.jl to avoid depending on either. Reverse-mode AD would unlock the true power of the augmented Lagrangian algorithm in Percival.jl since it avoids the computation of the whole Jacobian.