### PR TITLE
add exclude in tests

### DIFF
--- a/test/nlp/nlpmodelstest.jl
+++ b/test/nlp/nlpmodelstest.jl
@@ -11,19 +11,19 @@
 
       nlps = [nlp_ad, nlp_man]
       @testset "Check Consistency" begin
-        consistent_nlps(nlps)
+        consistent_nlps(nlps, exclude = [])
       end
       @testset "Check dimensions" begin
-        check_nlp_dimensions(nlp_ad)
+        check_nlp_dimensions(nlp_ad, exclude = [])
       end
       @testset "Check multiple precision" begin
-        multiple_precision_nlp(nlp_ad)
+        multiple_precision_nlp(nlp_ad, exclude = [])
       end
       @testset "Check view subarray" begin
-        view_subarray_nlp(nlp_ad)
+        view_subarray_nlp(nlp_ad, exclude = [])
       end
       @testset "Check coordinate memory" begin
-        coord_memory_nlp(nlp_ad)
+        coord_memory_nlp(nlp_ad, exclude = [])
       end
     end
   end

--- a/test/nls/nlpmodelstest.jl
+++ b/test/nls/nlpmodelstest.jl
@@ -14,24 +14,32 @@
         push!(nlss, eval(Meta.parse(spc))())
       end
 
+      exclude = if problem == "LLS" 
+        [hess_coord, hess]
+      elseif problem == "MGH01"
+        [hess_coord, hess, ghjvprod]
+      else
+        []
+      end
+
       for nls in nlss
         show(IOBuffer(), nls)
       end
 
       @testset "Check Consistency" begin
-        consistent_nlss([nlss; nls_man])
+        consistent_nlss([nlss; nls_man], exclude = exclude)
       end
       @testset "Check dimensions" begin
-        check_nls_dimensions.(nlss)
-        check_nlp_dimensions.(nlss, exclude_hess=true)
+        check_nls_dimensions.(nlss, exclude = exclude)
+        check_nlp_dimensions.(nlss, exclude = exclude)
       end
       @testset "Check multiple precision" begin
         for nls in nlss
-          multiple_precision_nls(nls)
+          multiple_precision_nls(nls, exclude = exclude)
         end
       end
       @testset "Check view subarray" begin
-        view_subarray_nls.(nlss)
+        view_subarray_nls.(nlss, exclude = exclude)
       end
     end
   end


### PR DESCRIPTION
- remove `exclude_hess` following [NLPModelsTest.jl PR #5](https://github.com/JuliaSmoothOptimizers/NLPModelsTest.jl/pull/5)
- set `exclude=[]` as ADNLPModels implements all the functions.
- MGH01 also test `FeasibilityResidual` which didn't implement `hess`, `hess_coord` and `ghjvprod`.
- LLS doesn't have `hess` and `hess_coord`.