### PR TITLE
Externalize dense hessian

### DIFF
--- a/src/ad.jl
+++ b/src/ad.jl
@@ -1,7 +1,49 @@
 abstract type ADBackend end
-struct ForwardDiffAD <: ADBackend end
-struct ZygoteAD <: ADBackend end
-struct ReverseDiffAD <: ADBackend end
+struct ForwardDiffAD <: ADBackend
+  nnzh::Int
+  nnzj::Int
+end
+function ForwardDiffAD(f, c, x0::AbstractVector, ncon::Integer)
+  nvar = length(x0)
+  nnzh = nvar * (nvar + 1) / 2
+  nnzj = nvar * ncon
+  return ForwardDiffAD(nnzh, nnzj)
+end
+function ForwardDiffAD(f, x0::AbstractVector)
+  nvar = length(x0)
+  nnzh = nvar * (nvar + 1) / 2
+  return ForwardDiffAD(nnzh, 0)
+end
+struct ZygoteAD <: ADBackend
+  nnzh::Int
+  nnzj::Int
+end
+function ZygoteAD(f, c, x0::AbstractVector, ncon::Integer)
+  nvar = length(x0)
+  nnzh = nvar * (nvar + 1) / 2
+  nnzj = nvar * ncon
+  return ZygoteAD(nnzh, nnzj)
+end
+function ZygoteAD(f, x0::AbstractVector)
+  nvar = length(x0)
+  nnzh = nvar * (nvar + 1) / 2
+  return ZygoteAD(nnzh, 0)
+end
+struct ReverseDiffAD <: ADBackend
+  nnzh::Int
+  nnzj::Int
+end
+function ReverseDiffAD(f, c, x0::AbstractVector, ncon::Integer)
+  nvar = length(x0)
+  nnzh = nvar * (nvar + 1) / 2
+  nnzj = nvar * ncon
+  return ReverseDiffAD(nnzh, nnzj)
+end
+function ReverseDiffAD(f, x0::AbstractVector)
+  nvar = length(x0)
+  nnzh = nvar * (nvar + 1) / 2
+  return ReverseDiffAD(nnzh, 0)
+end
 
 throw_error(b) =
   throw(ArgumentError("The AD backend $b is not loaded. Please load the corresponding AD package."))
@@ -11,6 +53,46 @@ jacobian(b::ADBackend, ::Any, ::Any) = throw_error(b)
 hessian(b::ADBackend, ::Any, ::Any) = throw_error(b)
 Jprod(b::ADBackend, ::Any, ::Any, ::Any) = throw_error(b)
 Jtprod(b::ADBackend, ::Any, ::Any, ::Any) = throw_error(b)
+function hess_structure!(
+  b::ADBackend,
+  nlp,
+  rows::AbstractVector{<:Integer},
+  cols::AbstractVector{<:Integer},
+)
+  n = nlp.meta.nvar
+  I = ((i, j) for i = 1:n, j = 1:n if i ≥ j)
+  rows .= getindex.(I, 1)
+  cols .= getindex.(I, 2)
+  return rows, cols
+end
+function hess_coord!(b::ADBackend, nlp, x::AbstractVector, ℓ::Function, vals::AbstractVector)
+  Hx = hessian(b, ℓ, x)
+  k = 1
+  for j = 1:(nlp.meta.nvar)
+    for i = j:(nlp.meta.nvar)
+      vals[k] = Hx[i, j]
+      k += 1
+    end
+  end
+  return vals
+end
+function jac_structure!(
+  b::ADBackend,
+  nlp,
+  rows::AbstractVector{<:Integer},
+  cols::AbstractVector{<:Integer},
+)
+  m, n = nlp.meta.ncon, nlp.meta.nvar
+  I = ((i, j) for i = 1:m, j = 1:n)
+  rows .= getindex.(I, 1)[:]
+  cols .= getindex.(I, 2)[:]
+  return rows, cols
+end
+function jac_coord!(b::ADBackend, nlp, x::AbstractVector, vals::AbstractVector)
+  Jx = jacobian(b, nlp.c, x)
+  vals .= Jx[:]
+  return vals
+end
 function directional_second_derivative(::ADBackend, f, x, v, w)
   return ForwardDiff.derivative(t -> ForwardDiff.derivative(s -> f(x + s * w + t * v), 0), 0)
 end
@@ -45,7 +127,7 @@ end
       return Zygote.jacobian(f, x)[1]
     end
     function hessian(b::ZygoteAD, f, x)
-      return jacobian(ForwardDiffAD(), x -> gradient(b, f, x), x)
+      return jacobian(ForwardDiffAD(f, x), x -> gradient(b, f, x), x)
     end
     function Jprod(::ZygoteAD, f, x, v)
       return vec(Zygote.jacobian(t -> f(x + t * v), 0)[1])

--- a/src/ad.jl
+++ b/src/ad.jl
@@ -3,14 +3,12 @@ struct ForwardDiffAD <: ADBackend
   nnzh::Int
   nnzj::Int
 end
-function ForwardDiffAD(f, c, x0::AbstractVector, ncon::Integer)
-  nvar = length(x0)
+function ForwardDiffAD(nvar::Integer, ncon::Integer)
   nnzh = nvar * (nvar + 1) / 2
   nnzj = nvar * ncon
   return ForwardDiffAD(nnzh, nnzj)
 end
-function ForwardDiffAD(f, x0::AbstractVector)
-  nvar = length(x0)
+function ForwardDiffAD(nvar::Integer)
   nnzh = nvar * (nvar + 1) / 2
   return ForwardDiffAD(nnzh, 0)
 end
@@ -18,14 +16,12 @@ struct ZygoteAD <: ADBackend
   nnzh::Int
   nnzj::Int
 end
-function ZygoteAD(f, c, x0::AbstractVector, ncon::Integer)
-  nvar = length(x0)
+function ZygoteAD(nvar::Integer, ncon::Integer)
   nnzh = nvar * (nvar + 1) / 2
   nnzj = nvar * ncon
   return ZygoteAD(nnzh, nnzj)
 end
-function ZygoteAD(f, x0::AbstractVector)
-  nvar = length(x0)
+function ZygoteAD(nvar::Integer)
   nnzh = nvar * (nvar + 1) / 2
   return ZygoteAD(nnzh, 0)
 end
@@ -33,14 +29,12 @@ struct ReverseDiffAD <: ADBackend
   nnzh::Int
   nnzj::Int
 end
-function ReverseDiffAD(f, c, x0::AbstractVector, ncon::Integer)
-  nvar = length(x0)
+function ReverseDiffAD(nvar::Integer, ncon::Integer)
   nnzh = nvar * (nvar + 1) / 2
   nnzj = nvar * ncon
   return ReverseDiffAD(nnzh, nnzj)
 end
-function ReverseDiffAD(f, x0::AbstractVector)
-  nvar = length(x0)
+function ReverseDiffAD(nvar::Integer)
   nnzh = nvar * (nvar + 1) / 2
   return ReverseDiffAD(nnzh, 0)
 end
@@ -127,7 +121,7 @@ end
       return Zygote.jacobian(f, x)[1]
     end
     function hessian(b::ZygoteAD, f, x)
-      return jacobian(ForwardDiffAD(f, x), x -> gradient(b, f, x), x)
+      return jacobian(ForwardDiffAD(length(x)), x -> gradient(b, f, x), x)
     end
     function Jprod(::ZygoteAD, f, x, v)
       return vec(Zygote.jacobian(t -> f(x + t * v), 0)[1])

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -327,15 +327,7 @@ function NLPModels.jth_hess_coord!(
   @lencheck nlp.meta.nvar x
   @rangecheck 1 nlp.meta.ncon j
   increment!(nlp, :neval_jhess)
-  Hx = hessian(nlp.adbackend, x -> nlp.c(x)[j], x)
-  k = 1
-  for j = 1:(nlp.meta.nvar)
-    for i = j:(nlp.meta.nvar)
-      vals[k] = Hx[i, j]
-      k += 1
-    end
-  end
-  return vals
+  return hess_coord!(nlp.adbackend, nlp, x, x -> nlp.c(x)[j], vals)
 end
 
 function NLPModels.jth_hprod!(

--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -39,7 +39,7 @@ function ADNLPModel(
   f,
   x0::AbstractVector{T};
   name::String = "Generic",
-  adbackend = ForwardDiffAD(f, x0),
+  adbackend = ForwardDiffAD(length(x0)),
 ) where {T}
   nvar = length(x0)
   @lencheck nvar x0
@@ -57,7 +57,7 @@ function ADNLPModel(
   lvar::AbstractVector,
   uvar::AbstractVector;
   name::String = "Generic",
-  adbackend = ForwardDiffAD(f, x0),
+  adbackend = ForwardDiffAD(length(x0)),
 ) where {T}
   nvar = length(x0)
   @lencheck nvar x0 lvar uvar
@@ -87,7 +87,7 @@ function ADNLPModel(
   y0::AbstractVector = fill!(similar(lcon), zero(T)),
   name::String = "Generic",
   lin::AbstractVector{<:Integer} = Int[],
-  adbackend = ForwardDiffAD(f, c, x0, length(lcon)),
+  adbackend = ForwardDiffAD(length(x0), length(lcon)),
 ) where {T}
   nvar = length(x0)
   ncon = length(lcon)
@@ -129,7 +129,7 @@ function ADNLPModel(
   y0::AbstractVector = fill!(similar(lcon), zero(T)),
   name::String = "Generic",
   lin::AbstractVector{<:Integer} = Int[],
-  adbackend = ForwardDiffAD(f, c, x0, length(lcon)),
+  adbackend = ForwardDiffAD(length(x0), length(lcon)),
 ) where {T}
   nvar = length(x0)
   ncon = length(lcon)

--- a/src/nls.jl
+++ b/src/nls.jl
@@ -46,7 +46,7 @@ function ADNLSModel(
   nequ::Integer;
   linequ::AbstractVector{<:Integer} = Int[],
   name::String = "Generic",
-  adbackend = ForwardDiffAD(F, x0),
+  adbackend = ForwardDiffAD(length(x0)),
 ) where {T}
   nvar = length(x0)
 
@@ -72,7 +72,7 @@ function ADNLSModel(
   uvar::AbstractVector;
   linequ::AbstractVector{<:Integer} = Int[],
   name::String = "Generic",
-  adbackend = ForwardDiffAD(F, x0),
+  adbackend = ForwardDiffAD(length(x0)),
 ) where {T}
   nvar = length(x0)
   @lencheck nvar lvar uvar
@@ -102,7 +102,7 @@ function ADNLSModel(
   lin::AbstractVector{<:Integer} = Int[],
   linequ::AbstractVector{<:Integer} = Int[],
   name::String = "Generic",
-  adbackend = ForwardDiffAD(F, c, x0, length(lcon)),
+  adbackend = ForwardDiffAD(length(x0), length(lcon)),
 ) where {T}
   nvar = length(x0)
   ncon = length(lcon)
@@ -148,7 +148,7 @@ function ADNLSModel(
   lin::AbstractVector{<:Integer} = Int[],
   linequ::AbstractVector{<:Integer} = Int[],
   name::String = "Generic",
-  adbackend = ForwardDiffAD(F, c, x0, length(lcon)),
+  adbackend = ForwardDiffAD(length(x0), length(lcon)),
 ) where {T}
   nvar = length(x0)
   ncon = length(lcon)

--- a/src/nls.jl
+++ b/src/nls.jl
@@ -456,15 +456,7 @@ function NLPModels.jth_hess_coord!(
   @lencheck nls.meta.nvar x
   @rangecheck 1 nls.meta.ncon j
   increment!(nls, :neval_jhess)
-  Hx = hessian(nls.adbackend, x -> nls.c(x)[j], x)
-  k = 1
-  for j = 1:(nls.meta.nvar)
-    for i = j:(nls.meta.nvar)
-      vals[k] = Hx[i, j]
-      k += 1
-    end
-  end
-  return vals
+  return hess_coord!(nls.adbackend, nls, x, x -> nls.c(x)[j], vals)
 end
 
 function NLPModels.jth_hprod!(

--- a/test/nlp/basic.jl
+++ b/test/nlp/basic.jl
@@ -25,16 +25,16 @@ function test_autodiff_model()
   for adbackend in (:ForwardDiffAD, :ZygoteAD, :ReverseDiffAD)
     x0 = zeros(2)
     f(x) = dot(x, x)
-    nlp = ADNLPModel(f, x0, adbackend = eval(adbackend)(f, x0))
+    nlp = ADNLPModel(f, x0, adbackend = eval(adbackend)(length(x0)))
 
     c(x) = [sum(x) - 1]
-    nlp = ADNLPModel(f, x0, c, [0], [0], adbackend = eval(adbackend)(f, c, x0, 1))
+    nlp = ADNLPModel(f, x0, c, [0], [0], adbackend = eval(adbackend)(length(x0), 1))
     @test obj(nlp, x0) == f(x0)
 
     x = range(-1, stop = 1, length = 100)
     y = 2x .+ 3 + randn(100) * 0.1
     regr = LinearRegression(x, y)
-    nlp = ADNLPModel(regr, ones(2), adbackend = eval(adbackend)(regr, ones(2)))
+    nlp = ADNLPModel(regr, ones(2), adbackend = eval(adbackend)(2))
     β = [ones(100) x] \ y
     @test abs(obj(nlp, β) - norm(y .- β[1] - β[2] * x)^2 / 2) < 1e-12
     @test norm(grad(nlp, β)) < 1e-12
@@ -42,8 +42,8 @@ function test_autodiff_model()
     @testset "Constructors for ADNLPModel" begin
       lvar, uvar, lcon, ucon, y0 = -ones(2), ones(2), -ones(1), ones(1), zeros(1)
       badlvar, baduvar, badlcon, baducon, bady0 = -ones(3), ones(3), -ones(2), ones(2), zeros(2)
-      unc_adbackend = eval(adbackend)(f, x0)
-      con_adbackend = eval(adbackend)(f, c, x0, 1)
+      unc_adbackend = eval(adbackend)(2)
+      con_adbackend = eval(adbackend)(2, 1)
       nlp = ADNLPModel(f, x0, adbackend = unc_adbackend)
       nlp = ADNLPModel(f, x0, lvar, uvar, adbackend = unc_adbackend)
       nlp = ADNLPModel(f, x0, c, lcon, ucon, adbackend = con_adbackend)

--- a/test/nlp/basic.jl
+++ b/test/nlp/basic.jl
@@ -9,8 +9,8 @@ function (regr::LinearRegression)(beta)
 end
 
 function test_autodiff_backend_error()
-  @testset "Error without loading package - $adbackend" for adbackend in
-                                                            [ZygoteAD(), ReverseDiffAD()]
+  @testset "Error without loading package - $adbackend" for adbackend in (:ZygoteAD, :ReverseDiffAD)
+    adbackend = eval(adbackend)(0, 0)
     @test_throws ArgumentError gradient(adbackend, sum, [1.0])
     @test_throws ArgumentError gradient!(adbackend, [1.0], sum, [1.0])
     @test_throws ArgumentError jacobian(adbackend, identity, [1.0])
@@ -22,19 +22,19 @@ function test_autodiff_backend_error()
 end
 
 function test_autodiff_model()
-  for adbackend in [ForwardDiffAD(), ZygoteAD(), ReverseDiffAD()]
+  for adbackend in (:ForwardDiffAD, :ZygoteAD, :ReverseDiffAD)
     x0 = zeros(2)
     f(x) = dot(x, x)
-    nlp = ADNLPModel(f, x0, adbackend = adbackend)
+    nlp = ADNLPModel(f, x0, adbackend = eval(adbackend)(f, x0))
 
     c(x) = [sum(x) - 1]
-    nlp = ADNLPModel(f, x0, c, [0], [0], adbackend = adbackend)
+    nlp = ADNLPModel(f, x0, c, [0], [0], adbackend = eval(adbackend)(f, c, x0, 1))
     @test obj(nlp, x0) == f(x0)
 
     x = range(-1, stop = 1, length = 100)
     y = 2x .+ 3 + randn(100) * 0.1
     regr = LinearRegression(x, y)
-    nlp = ADNLPModel(regr, ones(2), adbackend = adbackend)
+    nlp = ADNLPModel(regr, ones(2), adbackend = eval(adbackend)(regr, ones(2)))
     β = [ones(100) x] \ y
     @test abs(obj(nlp, β) - norm(y .- β[1] - β[2] * x)^2 / 2) < 1e-12
     @test norm(grad(nlp, β)) < 1e-12
@@ -42,16 +42,18 @@ function test_autodiff_model()
     @testset "Constructors for ADNLPModel" begin
       lvar, uvar, lcon, ucon, y0 = -ones(2), ones(2), -ones(1), ones(1), zeros(1)
       badlvar, baduvar, badlcon, baducon, bady0 = -ones(3), ones(3), -ones(2), ones(2), zeros(2)
-      nlp = ADNLPModel(f, x0, adbackend = adbackend)
-      nlp = ADNLPModel(f, x0, lvar, uvar, adbackend = adbackend)
-      nlp = ADNLPModel(f, x0, c, lcon, ucon, adbackend = adbackend)
-      nlp = ADNLPModel(f, x0, c, lcon, ucon, y0 = y0, adbackend = adbackend)
-      nlp = ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, adbackend = adbackend)
-      nlp = ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, y0 = y0, adbackend = adbackend)
-      @test_throws DimensionError ADNLPModel(f, x0, badlvar, uvar, adbackend = adbackend)
-      @test_throws DimensionError ADNLPModel(f, x0, lvar, baduvar, adbackend = adbackend)
-      @test_throws DimensionError ADNLPModel(f, x0, c, badlcon, ucon, adbackend = adbackend)
-      @test_throws DimensionError ADNLPModel(f, x0, c, lcon, baducon, adbackend = adbackend)
+      unc_adbackend = eval(adbackend)(f, x0)
+      con_adbackend = eval(adbackend)(f, c, x0, 1)
+      nlp = ADNLPModel(f, x0, adbackend = unc_adbackend)
+      nlp = ADNLPModel(f, x0, lvar, uvar, adbackend = unc_adbackend)
+      nlp = ADNLPModel(f, x0, c, lcon, ucon, adbackend = con_adbackend)
+      nlp = ADNLPModel(f, x0, c, lcon, ucon, y0 = y0, adbackend = con_adbackend)
+      nlp = ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, adbackend = con_adbackend)
+      nlp = ADNLPModel(f, x0, lvar, uvar, c, lcon, ucon, y0 = y0, adbackend = con_adbackend)
+      @test_throws DimensionError ADNLPModel(f, x0, badlvar, uvar, adbackend = unc_adbackend)
+      @test_throws DimensionError ADNLPModel(f, x0, lvar, baduvar, adbackend = unc_adbackend)
+      @test_throws DimensionError ADNLPModel(f, x0, c, badlcon, ucon, adbackend = con_adbackend)
+      @test_throws DimensionError ADNLPModel(f, x0, c, lcon, baducon, adbackend = con_adbackend)
       @test_throws DimensionError ADNLPModel(
         f,
         x0,
@@ -59,7 +61,7 @@ function test_autodiff_model()
         lcon,
         ucon,
         y0 = bady0,
-        adbackend = adbackend,
+        adbackend = con_adbackend,
       )
       @test_throws DimensionError ADNLPModel(
         f,
@@ -69,7 +71,7 @@ function test_autodiff_model()
         c,
         lcon,
         ucon,
-        adbackend = adbackend,
+        adbackend = con_adbackend,
       )
       @test_throws DimensionError ADNLPModel(
         f,
@@ -79,7 +81,7 @@ function test_autodiff_model()
         c,
         lcon,
         ucon,
-        adbackend = adbackend,
+        adbackend = con_adbackend,
       )
       @test_throws DimensionError ADNLPModel(
         f,
@@ -89,7 +91,7 @@ function test_autodiff_model()
         c,
         badlcon,
         ucon,
-        adbackend = adbackend,
+        adbackend = con_adbackend,
       )
       @test_throws DimensionError ADNLPModel(
         f,
@@ -99,7 +101,7 @@ function test_autodiff_model()
         c,
         lcon,
         baducon,
-        adbackend = adbackend,
+        adbackend = con_adbackend,
       )
       @test_throws DimensionError ADNLPModel(
         f,
@@ -110,7 +112,7 @@ function test_autodiff_model()
         lcon,
         ucon,
         y0 = bady0,
-        adbackend = adbackend,
+        adbackend = con_adbackend,
       )
     end
   end

--- a/test/nlp/nlpmodelstest.jl
+++ b/test/nlp/nlpmodelstest.jl
@@ -1,8 +1,9 @@
-@testset "AD backend - $(adbackend)" for adbackend in [ForwardDiffAD(), ZygoteAD(), ReverseDiffAD()]
+
+@testset "AD backend - $(adbackend)" for adbackend in (:ForwardDiffAD, :ZygoteAD, :ReverseDiffAD)
   for problem in NLPModelsTest.nlp_problems
     @testset "Checking NLPModelsTest tests on problem $problem" begin
       nlp_ad = eval(Meta.parse(lowercase(problem) * "_autodiff"))()
-      nlp_ad.adbackend = adbackend
+      nlp_ad.adbackend = eval(adbackend)(nlp_ad.f, nlp_ad.meta.x0)
       nlp_man = eval(Meta.parse(problem))()
 
       show(IOBuffer(), nlp_ad)

--- a/test/nlp/nlpmodelstest.jl
+++ b/test/nlp/nlpmodelstest.jl
@@ -3,7 +3,7 @@
   for problem in NLPModelsTest.nlp_problems
     @testset "Checking NLPModelsTest tests on problem $problem" begin
       nlp_ad = eval(Meta.parse(lowercase(problem) * "_autodiff"))()
-      nlp_ad.adbackend = eval(adbackend)(nlp_ad.f, nlp_ad.meta.x0)
+      nlp_ad.adbackend = eval(adbackend)(length(nlp_ad.meta.x0))
       nlp_man = eval(Meta.parse(problem))()
 
       show(IOBuffer(), nlp_ad)

--- a/test/nls/basic.jl
+++ b/test/nls/basic.jl
@@ -2,7 +2,7 @@ function autodiff_nls_test()
   for adbackend in (:ForwardDiffAD, :ZygoteAD, :ReverseDiffAD)
     @testset "autodiff_nls_test for $adbackend" begin
       F(x) = [x[1] - 1; x[2] - x[1]^2]
-      nls = ADNLSModel(F, zeros(2), 2, adbackend = eval(adbackend)(F, zeros(2)))
+      nls = ADNLSModel(F, zeros(2), 2, adbackend = eval(adbackend)(2))
 
       @test isapprox(residual(nls, ones(2)), zeros(2), rtol = 1e-8)
     end
@@ -13,8 +13,8 @@ function autodiff_nls_test()
       c(x) = [sum(x) - 1]
       lvar, uvar, lcon, ucon, y0 = -ones(2), ones(2), -ones(1), ones(1), zeros(1)
       badlvar, baduvar, badlcon, baducon, bady0 = -ones(3), ones(3), -ones(2), ones(2), zeros(2)
-      unc_adbackend = eval(adbackend)(F, x0)
-      con_adbackend = eval(adbackend)(F, c, x0, 1)
+      unc_adbackend = eval(adbackend)(2)
+      con_adbackend = eval(adbackend)(2, 1)
       nlp = ADNLSModel(F, x0, 3, adbackend = unc_adbackend)
       nlp = ADNLSModel(F, x0, 3, lvar, uvar, adbackend = unc_adbackend)
       nlp = ADNLSModel(F, x0, 3, c, lcon, ucon, adbackend = con_adbackend)

--- a/test/nls/nlpmodelstest.jl
+++ b/test/nls/nlpmodelstest.jl
@@ -1,8 +1,8 @@
-@testset "AD backend - $(adbackend)" for adbackend in [ForwardDiffAD(), ZygoteAD(), ReverseDiffAD()]
+@testset "AD backend - $(adbackend)" for adbackend in (:ForwardDiffAD, :ZygoteAD, :ReverseDiffAD)
   for problem in NLPModelsTest.nls_problems
     @testset "Checking NLPModelsTest tests on problem $problem" begin
       nls_ad = eval(Meta.parse(lowercase(problem) * "_autodiff"))()
-      nls_ad.adbackend = adbackend
+      nls_ad.adbackend = eval(adbackend)(nls_ad.F, nls_ad.meta.x0)
       nls_man = eval(Meta.parse(problem))()
 
       nlss = AbstractNLSModel[nls_ad]

--- a/test/nls/nlpmodelstest.jl
+++ b/test/nls/nlpmodelstest.jl
@@ -2,7 +2,7 @@
   for problem in NLPModelsTest.nls_problems
     @testset "Checking NLPModelsTest tests on problem $problem" begin
       nls_ad = eval(Meta.parse(lowercase(problem) * "_autodiff"))()
-      nls_ad.adbackend = eval(adbackend)(nls_ad.F, nls_ad.meta.x0)
+      nls_ad.adbackend = eval(adbackend)(length(nls_ad.meta.x0))
       nls_man = eval(Meta.parse(problem))()
 
       nlss = AbstractNLSModel[nls_ad]


### PR DESCRIPTION
This PR prepares the field for sparse construction of the Jacobian/Hessian matrix.
- `hess_coord` and `hess_structure` are backend specific
- `nnzj` and `nnzh` are attributes of the backend structure (later on we could also add precompiled Tape ...)