### PR TITLE
add jth-functions

### DIFF
--- a/src/nlp.jl
+++ b/src/nlp.jl
@@ -343,6 +343,41 @@ function NLPModels.hprod!(
   return Hv
 end
 
+function NLPModels.jth_hess_coord!(
+  nlp::ADNLPModel,
+  x::AbstractVector,
+  j::Integer,
+  vals::AbstractVector,
+)
+  @lencheck nlp.meta.nnzh vals
+  @lencheck nlp.meta.nvar x
+  @rangecheck 1 nlp.meta.ncon j
+  increment!(nlp, :neval_jhess)
+  Hx = hessian(nlp.adbackend, x -> nlp.c(x)[j], x)
+  k = 1
+  for j = 1 : nlp.meta.nvar
+    for i = j : nlp.meta.nvar
+      vals[k] = Hx[i, j]
+      k += 1
+    end
+  end
+  return vals
+end
+
+function NLPModels.jth_hprod!(
+  nlp::ADNLPModel,
+  x::AbstractVector,
+  v::AbstractVector,
+  j::Integer,
+  Hv::AbstractVector,
+)
+  @lencheck nlp.meta.nvar x v Hv
+  @rangecheck 1 nlp.meta.ncon j
+  increment!(nlp, :neval_jhprod)
+  Hv .= Hvprod(nlp.adbackend, x -> nlp.c(x)[j], x, v)
+  return Hv
+end
+
 function NLPModels.ghjvprod!(
   nlp::ADNLPModel,
   x::AbstractVector,

--- a/src/nls.jl
+++ b/src/nls.jl
@@ -472,6 +472,41 @@ function NLPModels.hprod!(
   return Hv
 end
 
+function NLPModels.jth_hess_coord!(
+  nls::ADNLSModel,
+  x::AbstractVector,
+  j::Integer,
+  vals::AbstractVector
+)
+  @lencheck nls.meta.nnzh vals
+  @lencheck nls.meta.nvar x
+  @rangecheck 1 nls.meta.ncon j
+  increment!(nls, :neval_jhess)
+  Hx = hessian(nls.adbackend, x -> nls.c(x)[j], x)
+  k = 1
+  for j = 1 : nls.meta.nvar
+    for i = j : nls.meta.nvar
+      vals[k] = Hx[i, j]
+      k += 1
+    end
+  end
+  return vals
+end
+
+function NLPModels.jth_hprod!(
+  nls::ADNLSModel,
+  x::AbstractVector,
+  v::AbstractVector,
+  j::Integer,
+  Hv::AbstractVector
+)
+  @lencheck nls.meta.nvar x v Hv
+  @rangecheck 1 nls.meta.ncon j
+  increment!(nls, :neval_jhprod)
+  Hv .= Hvprod(nls.adbackend, x -> nls.c(x)[j], x, v)
+  return Hv
+end
+
 function NLPModels.ghjvprod!(
   nls::ADNLSModel,
   x::AbstractVector,


### PR DESCRIPTION
Add implementation of `jth_hprod` and `jth_hess_coord` following [PR 340 in NLPModels.jl](https://github.com/JuliaSmoothOptimizers/NLPModels.jl/pull/340).

This was breaking in NLPModelsTest.jl [PR 6](https://github.com/JuliaSmoothOptimizers/NLPModelsTest.jl/pull/6)