### PR TITLE
Add `OptimizationProblems` in breakage

### DIFF
--- a/.github/workflows/Breakage.yml
+++ b/.github/workflows/Breakage.yml
@@ -14,10 +14,11 @@ jobs:
       matrix:
         pkg: [
           "JuliaSmoothOptimizers/CaNNOLeS.jl",
-          "JuliaSmoothOptimizers/DCI.jl",
+          "JuliaSmoothOptimizers/DCISolver.jl",
           "JuliaSmoothOptimizers/DerivativeFreeSolvers.jl",
           "JuliaSmoothOptimizers/JSOSolvers.jl",
           "JuliaSmoothOptimizers/NLPModelsIpopt.jl",
+          "JuliaSmoothOptimizers/OptimizationProblems.jl",
           "JuliaSmoothOptimizers/Percival.jl",
           "JuliaSmoothOptimizers/QuadraticModels.jl",
           "JuliaSmoothOptimizers/SolverBenchmark.jl",


### PR DESCRIPTION
Since [PR 66 in OptimizationProblems.jl](https://github.com/JuliaSmoothOptimizers/OptimizationProblems.jl/pull/66), the package uses ADNLP problems.

I also updated the name for DCI.