### PR TITLE
Add setter for backend

### DIFF
--- a/src/ADNLPModels.jl
+++ b/src/ADNLPModels.jl
@@ -28,7 +28,7 @@ get_adbackend(nlp::Union{ADNLPModel, ADNLSModel}) = nlp.adbackend
     set_adbackend!(nlp, new_adbackend)
     set_adbackend!(nlp; kwargs...)
 
-Replace the current `adbackend` value of nlp by `new_adbackend` or instantiate a new one with `kwargs`, see [`ADModelBackend`](@ref).
+Replace the current `adbackend` value of nlp by `new_adbackend` or instantiate a new one with `kwargs`, see `ADModelBackend`.
 By default, the setter with kwargs will reuse existing backends.
 """
 function set_adbackend!(nlp::Union{ADNLPModel, ADNLSModel}, new_adbackend::ADModelBackend)

--- a/src/ADNLPModels.jl
+++ b/src/ADNLPModels.jl
@@ -18,7 +18,7 @@ include("nls.jl")
 export get_adbackend, set_adbackend!
 
 """
-    has_adbackend(nlp)
+    get_adbackend(nlp)
 
 Returns the value `adbackend` from nlp.
 """

--- a/test/nlp/basic.jl
+++ b/test/nlp/basic.jl
@@ -55,6 +55,8 @@ function test_autodiff_model(name; kwargs...)
   β = [ones(100) x] \ y
   @test abs(obj(nlp, β) - norm(y .- β[1] - β[2] * x)^2 / 2) < 1e-12
   @test norm(grad(nlp, β)) < 1e-12
+  
+  test_getter_setter(nlp)
 
   @testset "Constructors for ADNLPModel with $name" begin
     lvar, uvar, lcon, ucon, y0 = -ones(2), ones(2), -ones(1), ones(1), zeros(1)

--- a/test/nls/basic.jl
+++ b/test/nls/basic.jl
@@ -4,6 +4,8 @@ function autodiff_nls_test(name; kwargs...)
     nls = ADNLSModel(F, zeros(2), 2; kwargs...)
 
     @test isapprox(residual(nls, ones(2)), zeros(2), rtol = 1e-8)
+
+    test_getter_setter(nls)
   end
 
   @testset "Constructors for ADNLSModel" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,6 +29,32 @@ ZygoteAD() = ADNLPModels.ADModelBackend(
   hessian_backend = ADNLPModels.ZygoteADHessian,
 )
 
+function test_getter_setter(nlp)
+  @test get_adbackend(nlp) == nlp.adbackend
+  if typeof(nlp) <: ADNLPModel
+    set_adbackend!(nlp, ReverseDiffAD(nlp.meta.nvar, nlp.f))
+  elseif typeof(nlp) <: ADNLSModel
+    set_adbackend!(nlp, ReverseDiffAD(nlp.meta.nvar, x -> sum(nlp.F(x) .^ 2)))
+  end
+  @test typeof(get_adbackend(nlp).gradient_backend) <: ADNLPModels.ReverseDiffADGradient
+  @test typeof(get_adbackend(nlp).hprod_backend) <: ADNLPModels.ReverseDiffADHvprod
+  @test typeof(get_adbackend(nlp).jprod_backend) <: ADNLPModels.ReverseDiffADJprod
+  @test typeof(get_adbackend(nlp).jtprod_backend) <: ADNLPModels.ReverseDiffADJtprod
+  @test typeof(get_adbackend(nlp).jacobian_backend) <: ADNLPModels.ReverseDiffADJacobian
+  @test typeof(get_adbackend(nlp).hessian_backend) <: ADNLPModels.ReverseDiffADHessian
+  set_adbackend!(
+    nlp,
+    gradient_backend = ADNLPModels.ForwardDiffADGradient,
+    jtprod_backend = ADNLPModels.ForwardDiffADJtprod(),
+  )
+  @test typeof(get_adbackend(nlp).gradient_backend) <: ADNLPModels.ForwardDiffADGradient
+  @test typeof(get_adbackend(nlp).hprod_backend) <: ADNLPModels.ReverseDiffADHvprod
+  @test typeof(get_adbackend(nlp).jprod_backend) <: ADNLPModels.ReverseDiffADJprod
+  @test typeof(get_adbackend(nlp).jtprod_backend) <: ADNLPModels.ForwardDiffADJtprod
+  @test typeof(get_adbackend(nlp).jacobian_backend) <: ADNLPModels.ReverseDiffADJacobian
+  @test typeof(get_adbackend(nlp).hessian_backend) <: ADNLPModels.ReverseDiffADHessian
+end
+
 include("nlp/basic.jl")
 include("nls/basic.jl")
 include("nlp/nlpmodelstest.jl")


### PR DESCRIPTION
As mentioned in https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl/pull/55#issuecomment-1109299069

I think we can also close https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl/issues/46 for instance:
```
using ADNLPModels, NLPModels
nlp = ADNLPModel(sum, ones(3))
grad(nlp, nlp.meta.x0)
set_adbackend!(nlp, gradient_backend = ADNLPModels.ForwardDiffADGradient, x0 = ones(Float32, 3))
grad(nlp, rand(Float32, 3))
```