### PR TITLE
Add linear api

### DIFF
--- a/src/ad.jl
+++ b/src/ad.jl
@@ -73,7 +73,7 @@ function jac_structure!(
   rows::AbstractVector{<:Integer},
   cols::AbstractVector{<:Integer},
 )
-  m, n = nlp.meta.ncon, nlp.meta.nvar
+  m, n = nlp.meta.nnln, nlp.meta.nvar
   I = ((i, j) for i = 1:m, j = 1:n)
   rows .= getindex.(I, 1)[:]
   cols .= getindex.(I, 2)[:]

--- a/test/nlp/basic.jl
+++ b/test/nlp/basic.jl
@@ -112,6 +112,8 @@ function test_autodiff_model(name; kwargs...)
     @test A == sparse(nlp.clinrows, nlp.clincols, nlp.clinvals)
     nlp = ADNLPModel(f, x0, lvar, uvar, A, lcon, ucon)
     @test A == sparse(nlp.clinrows, nlp.clincols, nlp.clinvals)
+    nlp = ADNLPModel(f, x0, lvar, uvar, A, lcon, ucon)
+    @test A == sparse(nlp.clinrows, nlp.clincols, nlp.clinvals)
   end
 end
 

--- a/test/nlp/problems/hs14.jl
+++ b/test/nlp/problems/hs14.jl
@@ -3,9 +3,13 @@ export hs14_autodiff
 function hs14_autodiff(::Type{T} = Float64; kwargs...) where {T}
   x0 = T[2.0; 2.0]
   f(x) = (x[1] - 2)^2 + (x[2] - 1)^2
-  c(x) = [x[1] - 2 * x[2] + 1; -x[1]^2 / 4 - x[2]^2 + 1]
-  lcon = T[0.0; 0.0]
-  ucon = T[0.0; Inf]
+  c(x) = [-x[1]^2 / 4 - x[2]^2 + 1]
+  lcon = T[-1; 0.0]
+  ucon = T[-1; Inf]
 
-  return ADNLPModel(f, x0, c, lcon, ucon, name = "hs14_autodiff"; kwargs...)
+  clinrows = [1, 1]
+  clincols = [1, 2]
+  clinvals = T[1, -2]
+
+  return ADNLPModel(f, x0, clinrows, clincols, clinvals, c, lcon, ucon, name = "hs14_autodiff"; kwargs...)
 end

--- a/test/nlp/problems/lincon.jl
+++ b/test/nlp/problems/lincon.jl
@@ -10,18 +10,13 @@ function lincon_autodiff(::Type{T} = Float64; kwargs...) where {T}
 
   x0 = zeros(T, 15)
   f(x) = sum(i + x[i]^4 for i = 1:15)
-  con(x) = [
-    15 * x[15]
-    c' * x[10:12]
-    d' * x[13:14]
-    b' * x[8:9]
-    C * x[6:7]
-    A * x[1:2]
-    B * x[3:5]
-  ]
 
   lcon = T[22.0; 1.0; -Inf; -11.0; -d; -b; -Inf * ones(3)]
   ucon = T[22.0; Inf; 16.0; 9.0; -d; Inf * ones(2); c]
 
-  return ADNLPModel(f, x0, con, lcon, ucon, name = "lincon_autodiff"; kwargs...)
+  clinrows = [1,   2,  2,  2,  3,  3, 4, 4, 5, 6, 7, 8, 7, 8, 9, 10, 11]
+  clincols = [15, 10, 11, 12, 13, 14, 8, 9, 7, 6, 1, 1, 2, 2, 3,  4, 5]
+  clinvals = vcat(T(15), c, d, b, C[1, 2], C[2, 1], A[:], diag(B))
+
+  return ADNLPModel(f, x0, clinrows, clincols, clinvals, lcon, ucon, name = "lincon_autodiff", lin = collect(1:11); kwargs...)
 end

--- a/test/nlp/problems/linsv.jl
+++ b/test/nlp/problems/linsv.jl
@@ -3,9 +3,12 @@ export linsv_autodiff
 function linsv_autodiff(::Type{T} = Float64; kwargs...) where {T}
   x0 = zeros(T, 2)
   f(x) = x[1]
-  con(x) = [x[1] + x[2]; x[2]]
   lcon = T[3.0; 1.0]
   ucon = T[Inf; Inf]
 
-  return ADNLPModel(f, x0, con, lcon, ucon, name = "linsv_autodiff"; kwargs...)
+  clinrows = [1, 1, 2]
+  clincols = [1, 2, 2]
+  clinvals = T[1, 1, 1]
+
+  return ADNLPModel(f, x0, clinrows, clincols, clinvals, lcon, ucon, name = "linsv_autodiff", lin = collect(1:2); kwargs...)
 end

--- a/test/nlp/problems/mgh01feas.jl
+++ b/test/nlp/problems/mgh01feas.jl
@@ -3,9 +3,13 @@ export mgh01feas_autodiff
 function mgh01feas_autodiff(::Type{T} = Float64; kwargs...) where {T}
   x0 = T[-1.2; 1.0]
   f(x) = zero(eltype(x))
-  c(x) = [1 - x[1]; 10 * (x[2] - x[1]^2)]
-  lcon = zeros(T, 2)
-  ucon = zeros(T, 2)
+  c(x) = [10 * (x[2] - x[1]^2)]
+  lcon = T[1, 0]
+  ucon = T[1, 0]
 
-  return ADNLPModel(f, x0, c, lcon, ucon, name = "mgh01feas_autodiff"; kwargs...)
+  clinrows = [1]
+  clincols = [1]
+  clinvals = T[1]
+
+  return ADNLPModel(f, x0, clinrows, clincols, clinvals, c, lcon, ucon, name = "mgh01feas_autodiff"; kwargs...)
 end

--- a/test/nls/problems/lls.jl
+++ b/test/nls/problems/lls.jl
@@ -3,9 +3,12 @@ export lls_autodiff
 function lls_autodiff(::Type{T} = Float64; kwargs...) where {T}
   x0 = zeros(T, 2)
   F(x) = [x[1] - x[2]; x[1] + x[2] - 2; x[2] - 2]
-  c(x) = [x[1] + x[2]]
   lcon = T[0.0]
   ucon = T[Inf]
 
-  return ADNLSModel(F, x0, 3, c, lcon, ucon, name = "lls_autodiff"; kwargs...)
+  clinrows = [1, 1]
+  clincols = [1, 2]
+  clinvals = T[1, 1]
+
+  return ADNLSModel(F, x0, 3, clinrows, clincols, clinvals, lcon, ucon, name = "lls_autodiff"; kwargs...)
 end

--- a/test/nls/problems/mgh01.jl
+++ b/test/nls/problems/mgh01.jl
@@ -1,4 +1,4 @@
-export MGH01_special, mgh01_autodiff
+export mgh01_autodiff # , MGH01_special
 
 function mgh01_autodiff(::Type{T} = Float64; kwargs...) where {T}
   x0 = T[-1.2; 1.0]
@@ -7,4 +7,4 @@ function mgh01_autodiff(::Type{T} = Float64; kwargs...) where {T}
   return ADNLSModel(F, x0, 2, name = "mgh01_autodiff"; kwargs...)
 end
 
-MGH01_special() = FeasibilityResidual(MGH01Feas())
+# MGH01_special() = FeasibilityResidual(MGH01Feas())

--- a/test/nls/problems/nlslc.jl
+++ b/test/nls/problems/nlslc.jl
@@ -10,18 +10,13 @@ function nlslc_autodiff(::Type{T} = Float64; kwargs...) where {T}
 
   x0 = zeros(T, 15)
   F(x) = [x[i]^2 - i^2 for i = 1:15]
-  con(x) = [
-    15 * x[15]
-    c' * x[10:12]
-    d' * x[13:14]
-    b' * x[8:9]
-    C * x[6:7]
-    A * x[1:2]
-    B * x[3:5]
-  ]
 
   lcon = T[22.0; 1.0; -Inf; -11.0; -d; -b; -Inf * ones(3)]
   ucon = T[22.0; Inf; 16.0; 9.0; -d; Inf * ones(2); c]
 
-  return ADNLSModel(F, x0, 15, con, lcon, ucon, name = "nlslincon_autodiff"; kwargs...)
+  clinrows = [1,   2,  2,  2,  3,  3, 4, 4, 5, 6, 7, 8, 7, 8, 9, 10, 11]
+  clincols = [15, 10, 11, 12, 13, 14, 8, 9, 7, 6, 1, 1, 2, 2, 3,  4, 5]
+  clinvals = vcat(T(15), c, d, b, C[1, 2], C[2, 1], A[:], diag(B))
+
+  return ADNLSModel(F, x0, 15, clinrows, clincols, clinvals, lcon, ucon, name = "nlslincon_autodiff"; kwargs...)
 end


### PR DESCRIPTION
Finally, the update with the linear API. Again this is a large PR so here is a recap':
- I updated all the problems in test folder to match the linear API.
- We now have `SparseArrays` in the deps
- `ADNLPModel` and `ADNLSModel` store four vectors for the linear constraint function `Ax + blin`
- There are two new constructor per model + two extras when the user passes a matrix instead of the COO-triplet
- I removed the possibility to provide linear constraints via the `lin` keyword.
- The rest is the implementation of the linear API (recall that for efficiency we also reimplement `jtprod!`).