### PR TITLE
Rename SparseForwardADJacobian backend

### DIFF
--- a/src/ad.jl
+++ b/src/ad.jl
@@ -20,13 +20,13 @@ where the `kwargs` are either the different backends as listed below or argument
   - `hprod_backend = ForwardDiffADHvprod`;
   - `jprod_backend = ForwardDiffADJprod`;
   - `jtprod_backend = ForwardDiffADJtprod`;
-  - `jacobian_backend = SparseForwardADJacobian`;
+  - `jacobian_backend = SparseADJacobian`;
   - `hessian_backend = ForwardDiffADHessian`;
   - `ghjvprod_backend = ForwardDiffADGHjvprod`;
   - `hprod_residual_backend = ForwardDiffADHvprod` for `ADNLSModel` and `EmptyADbackend` otherwise;
   - `jprod_residual_backend = ForwardDiffADJprod` for `ADNLSModel` and `EmptyADbackend` otherwise;
   - `jtprod_residual_backend = ForwardDiffADJtprod` for `ADNLSModel` and `EmptyADbackend` otherwise;
-  - `jacobian_residual_backend = SparseForwardADJacobian` for `ADNLSModel` and `EmptyADbackend` otherwise;
+  - `jacobian_residual_backend = SparseADJacobian` for `ADNLSModel` and `EmptyADbackend` otherwise;
   - `hessian_residual_backend = ForwardDiffADHessian` for `ADNLSModel` and `EmptyADbackend` otherwise.
 
 """
@@ -73,7 +73,7 @@ function ADModelBackend(
   hprod_backend::Type{HvB} = ForwardDiffADHvprod,
   jprod_backend::Type{JvB} = ForwardDiffADJprod,
   jtprod_backend::Type{JtvB} = ForwardDiffADJtprod,
-  jacobian_backend::Type{JB} = SparseForwardADJacobian,
+  jacobian_backend::Type{JB} = SparseADJacobian,
   hessian_backend::Type{HB} = SparseADHessian,
   ghjvprod_backend::Type{GHJ} = ForwardDiffADGHjvprod,
   kwargs...,
@@ -104,13 +104,13 @@ function ADModelNLSBackend(
   hprod_backend::Type{HvB} = ForwardDiffADHvprod,
   jprod_backend::Type{JvB} = ForwardDiffADJprod,
   jtprod_backend::Type{JtvB} = ForwardDiffADJtprod,
-  jacobian_backend::Type{JB} = SparseForwardADJacobian,
+  jacobian_backend::Type{JB} = SparseADJacobian,
   hessian_backend::Type{HB} = SparseADHessian,
   ghjvprod_backend::Type{GHJ} = ForwardDiffADGHjvprod,
   hprod_residual_backend::Type{HvBLS} = ForwardDiffADHvprod,
   jprod_residual_backend::Type{JvBLS} = ForwardDiffADJprod,
   jtprod_residual_backend::Type{JtvBLS} = ForwardDiffADJtprod,
-  jacobian_residual_backend::Type{JBLS} = SparseForwardADJacobian,
+  jacobian_residual_backend::Type{JBLS} = SparseADJacobian,
   hessian_residual_backend::Type{HBLS} = ForwardDiffADHessian,
   kwargs...,
 ) where {GB, HvB, JvB, JtvB, JB, HB, GHJ, HvBLS, JvBLS, JtvBLS, JBLS, HBLS}

--- a/src/sparse_jacobian.jl
+++ b/src/sparse_jacobian.jl
@@ -1,10 +1,8 @@
-## ----- SparseDiffTools -----
-
-struct SparseForwardADJacobian{Tv, Ti, T, T2, T3, T4, T5} <: ADNLPModels.ADBackend
+struct SparseADJacobian{Tv, Ti, T, T2, T3, T4, T5} <: ADNLPModels.ADBackend
   cfJ::ForwardColorJacCache{T, T2, T3, T4, T5, SparseMatrixCSC{Tv, Ti}}
 end
 
-function SparseForwardADJacobian(
+function SparseADJacobian(
   nvar,
   f,
   ncon,
@@ -20,15 +18,15 @@ function SparseForwardADJacobian(
 
   dx = zeros(T, ncon)
   cfJ = ForwardColorJacCache(c!, x0, colorvec = colors, dx = dx, sparsity = jac)
-  SparseForwardADJacobian(cfJ)
+  SparseADJacobian(cfJ)
 end
 
-function get_nln_nnzj(b::SparseForwardADJacobian, nvar, ncon)
+function get_nln_nnzj(b::SparseADJacobian, nvar, ncon)
   nnz(b.cfJ.sparsity)
 end
 
 function jac_structure!(
-  b::SparseForwardADJacobian,
+  b::SparseADJacobian,
   nlp::ADModel,
   rows::AbstractVector{<:Integer},
   cols::AbstractVector{<:Integer},
@@ -43,7 +41,7 @@ function jac_structure!(
 end
 
 function jac_coord!(
-  b::SparseForwardADJacobian,
+  b::SparseADJacobian,
   nlp::ADModel,
   x::AbstractVector,
   vals::AbstractVector,
@@ -54,7 +52,7 @@ function jac_coord!(
 end
 
 function jac_structure_residual!(
-  b::SparseForwardADJacobian,
+  b::SparseADJacobian,
   nls::AbstractADNLSModel,
   rows::AbstractVector{<:Integer},
   cols::AbstractVector{<:Integer},
@@ -69,7 +67,7 @@ function jac_structure_residual!(
 end
 
 function jac_coord_residual!(
-  b::SparseForwardADJacobian,
+  b::SparseADJacobian,
   nls::AbstractADNLSModel,
   x::AbstractVector,
   vals::AbstractVector,

--- a/test/sparse_jacobian.jl
+++ b/test/sparse_jacobian.jl
@@ -1,6 +1,6 @@
 list_sparse_jac_backend = (
-  (ADNLPModels.SparseForwardADJacobian, Dict(:alg => SparseDiffTools.GreedyD1Color())),
-  (ADNLPModels.SparseForwardADJacobian, Dict(:alg => SparseDiffTools.AcyclicColoring())),
+  (ADNLPModels.SparseADJacobian, Dict(:alg => SparseDiffTools.GreedyD1Color())),
+  (ADNLPModels.SparseADJacobian, Dict(:alg => SparseDiffTools.AcyclicColoring())),
   (ADNLPModels.ForwardDiffADJacobian, Dict()),
   (ADNLPModels.SparseSymbolicsADJacobian, Dict()),
 )

--- a/test/sparse_jacobian_nls.jl
+++ b/test/sparse_jacobian_nls.jl
@@ -1,6 +1,6 @@
 list_sparse_jac_backend = (
-  (ADNLPModels.SparseForwardADJacobian, Dict(:alg => SparseDiffTools.GreedyD1Color())),
-  (ADNLPModels.SparseForwardADJacobian, Dict(:alg => SparseDiffTools.AcyclicColoring())),
+  (ADNLPModels.SparseADJacobian, Dict(:alg => SparseDiffTools.GreedyD1Color())),
+  (ADNLPModels.SparseADJacobian, Dict(:alg => SparseDiffTools.AcyclicColoring())),
   (ADNLPModels.ForwardDiffADJacobian, Dict()),
   (ADNLPModels.SparseSymbolicsADJacobian, Dict()),
 )


### PR DESCRIPTION
We will be consistent with the name used for sparse Hessian backends.