### PR TITLE
Use ColPack instead of SparseDiffTools for coloration

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,20 +3,20 @@ uuid = "54578032-b7ea-4c30-94aa-7cbd1cce6c9a"
 version = "0.6.2"
 
 [deps]
+ColPack = "ffa27691-3a59-46ab-a8d4-551f45b8d401"
 ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NLPModels = "a4795742-8479-5a88-8948-cc11e1c8c1a6"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 ReverseDiff = "37e2e3b7-166d-5795-8a7a-e32c996b4267"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-SparseDiffTools = "47a9eef4-7e08-11e9-0b38-333d64bd3804"
 Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [compat]
+ColPack = "0.3"
 ForwardDiff = "0.9.0, 0.10.0"
 NLPModels = "0.18, 0.19, 0.20"
 Requires = "1"
 ReverseDiff = "1"
-SparseDiffTools = "1.30, 2"
 Symbolics = "^5.2"
 julia = "^1.6"

--- a/src/ADNLPModels.jl
+++ b/src/ADNLPModels.jl
@@ -3,7 +3,7 @@ module ADNLPModels
 # stdlib
 using LinearAlgebra, SparseArrays
 # external
-using ForwardDiff, ReverseDiff, SparseDiffTools, Symbolics
+using ColPack, ForwardDiff, ReverseDiff, Symbolics
 # JSO
 using NLPModels
 using Requires

--- a/src/ad.jl
+++ b/src/ad.jl
@@ -341,18 +341,18 @@ end
 
 abstract type ColorationAlgorithm end
 
-struct ColPackColoration{F} <: ColorationAlgorithm
+struct ColPackColoration{F, C, O} <: ColorationAlgorithm
   partition_choice::F
-  coloring
-  ordering
+  coloring::C
+  ordering::O
 end
 
 function ColPackColoration(;
-  partition_choice = (m, n; μ = 0.6) -> n < μ * m ? true : false,
-  coloring = d1_coloring("DISTANCE_ONE"),
-  ordering = incidence_degree_ordering("INCIDENCE_DEGREE"),
+  partition_choice = (m, n) -> false, # TODO: (m, n; μ = 0.6) -> n < μ * m ? true : false,
+  coloring::ColPack.AbstractColoring = d1_coloring("DISTANCE_ONE"),
+  ordering::ColPack.AbstractOrdering = incidence_degree_ordering("INCIDENCE_DEGREE"),
   )
-  return ColPackColoration{typeof(partition_choice)}(partition_choice, coloring, ordering)
+  return ColPackColoration{typeof(partition_choice), typeof(coloring), typeof(ordering)}(partition_choice, coloring, ordering)
 end
 
 function sparse_matrix_colors(A, alg::ColPackColoration)

--- a/src/ad.jl
+++ b/src/ad.jl
@@ -358,7 +358,7 @@ end
 function sparse_matrix_colors(A, alg::ColPackColoration)
   m, n = size(A)
   partition_by_rows = alg.partition_choice(m, n)
-  if A != spzeros(m, n)
+  if !isempty(A.nzval)
     adjA = ColPack.matrix2adjmatrix(A; partition_by_rows=partition_by_rows)
     CPC = ColPackColoring(adjA, alg.coloring, alg.ordering)
     colors = get_colors(CPC)

--- a/src/ad.jl
+++ b/src/ad.jl
@@ -358,7 +358,7 @@ end
 function sparse_matrix_colors(A, alg::ColPackColoration)
   m, n = size(A)
   partition_by_rows = alg.partition_choice(m, n)
-  if A != spzeros(size(A))
+  if A != spzeros(m, n)
     adjA = ColPack.matrix2adjmatrix(A; partition_by_rows=partition_by_rows)
     CPC = ColPackColoring(adjA, alg.coloring, alg.ordering)
     colors = get_colors(CPC)

--- a/src/sparse_hessian.jl
+++ b/src/sparse_hessian.jl
@@ -13,7 +13,7 @@ function SparseADHessian(
   ncon,
   c!;
   x0 = rand(nvar),
-  alg::SparseDiffTools.SparseDiffToolsColoringAlgorithm = SparseDiffTools.GreedyD1Color(),
+  alg = ColPackColoration(),
   kwargs...,
 )
   @variables xs[1:nvar]
@@ -27,9 +27,11 @@ function SparseADHessian(
   end
   S = Symbolics.hessian_sparsity(fun, ncon == 0 ? xsi : [xsi; ysi]) # , full = false
   H = ncon == 0 ? S : S[1:nvar, 1:nvar]
-  colors = matrix_colors(H, alg)
-  d = BitVector(undef, nvar)
+
+  colors = sparse_matrix_colors(H, alg)
   ncolors = maximum(colors)
+
+  d = BitVector(undef, nvar)
 
   trilH = tril(H)
   rowval = trilH.rowval

--- a/src/sparse_jacobian.jl
+++ b/src/sparse_jacobian.jl
@@ -15,14 +15,16 @@ function SparseADJacobian(
   ncon,
   c!;
   x0::AbstractVector{T} = rand(nvar),
-  alg::SparseDiffTools.SparseDiffToolsColoringAlgorithm = SparseDiffTools.GreedyD1Color(),
+  alg = ColPackColoration(),
   kwargs...,
 ) where {T}
   output = similar(x0, ncon)
   J = Symbolics.jacobian_sparsity(c!, output, x0)
-  colors = matrix_colors(J, alg)
-  d = BitVector(undef, nvar)
+
+  colors = sparse_matrix_colors(J, alg)
   ncolors = maximum(colors)
+
+  d = BitVector(undef, nvar)
 
   rowval = J.rowval
   colptr = J.colptr

--- a/test/sparse_hessian.jl
+++ b/test/sparse_hessian.jl
@@ -1,6 +1,7 @@
 list_sparse_hess_backend = (
-  (ADNLPModels.SparseADHessian, Dict(:alg => SparseDiffTools.GreedyD1Color())),
-  (ADNLPModels.SparseADHessian, Dict(:alg => SparseDiffTools.AcyclicColoring())),
+  (ADNLPModels.SparseADHessian, Dict()),
+  #(ADNLPModels.SparseADHessian, Dict(:alg => SparseDiffTools.GreedyD1Color())),
+  #(ADNLPModels.SparseADHessian, Dict(:alg => SparseDiffTools.AcyclicColoring())),
   (ADNLPModels.ForwardDiffADHessian, Dict()),
   (ADNLPModels.SparseSymbolicsADHessian, Dict()),
 )

--- a/test/sparse_jacobian.jl
+++ b/test/sparse_jacobian.jl
@@ -1,6 +1,7 @@
 list_sparse_jac_backend = (
-  (ADNLPModels.SparseADJacobian, Dict(:alg => SparseDiffTools.GreedyD1Color())),
-  (ADNLPModels.SparseADJacobian, Dict(:alg => SparseDiffTools.AcyclicColoring())),
+  (ADNLPModels.SparseADJacobian, Dict()), # default
+  #(ADNLPModels.SparseADJacobian, Dict(:alg => SparseDiffTools.GreedyD1Color())),
+  #(ADNLPModels.SparseADJacobian, Dict(:alg => SparseDiffTools.AcyclicColoring())),
   (ADNLPModels.ForwardDiffADJacobian, Dict()),
   (ADNLPModels.SparseSymbolicsADJacobian, Dict()),
 )

--- a/test/sparse_jacobian_nls.jl
+++ b/test/sparse_jacobian_nls.jl
@@ -1,6 +1,7 @@
 list_sparse_jac_backend = (
-  (ADNLPModels.SparseADJacobian, Dict(:alg => SparseDiffTools.GreedyD1Color())),
-  (ADNLPModels.SparseADJacobian, Dict(:alg => SparseDiffTools.AcyclicColoring())),
+  (ADNLPModels.SparseADJacobian, Dict()), # default
+  #(ADNLPModels.SparseADJacobian, Dict(:alg => SparseDiffTools.GreedyD1Color())),
+  #(ADNLPModels.SparseADJacobian, Dict(:alg => SparseDiffTools.AcyclicColoring())),
   (ADNLPModels.ForwardDiffADJacobian, Dict()),
   (ADNLPModels.SparseSymbolicsADJacobian, Dict()),
 )


### PR DESCRIPTION
This will simplify the dependencies of the package.

I will add SparseDiffTools as an optional dependency after this one.

Some results:
https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl/blob/benchmark/benchmark/coloration.jl
https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl/blob/benchmark/benchmark/coloration1000.dat