### PR TITLE
Add test for mixed models (NLP)

### DIFF
--- a/test/nlp/nlpmodelstest.jl
+++ b/test/nlp/nlpmodelstest.jl
@@ -1,5 +1,5 @@
-@testset "Checking NLPModelsTest tests with $backend" for backend in
-                                                          keys(ADNLPModels.predefined_backend)
+@testset "Checking NLPModelsTest (NLP) tests with $backend" for backend in
+                                                                keys(ADNLPModels.predefined_backend)
   @testset "Checking NLPModelsTest tests on problem $problem" for problem in
                                                                   NLPModelsTest.nlp_problems
     nlp_from_T = eval(Meta.parse(lowercase(problem) * "_autodiff"))

--- a/test/nls/nlpmodelstest.jl
+++ b/test/nls/nlpmodelstest.jl
@@ -1,5 +1,5 @@
-@testset "Checking NLPModelsTest tests with $backend" for backend in
-                                                          keys(ADNLPModels.predefined_backend)
+@testset "Checking NLPModelsTest (NLS) tests with $backend" for backend in
+                                                                keys(ADNLPModels.predefined_backend)
   @testset "Checking NLPModelsTest tests on problem $problem" for problem in
                                                                   NLPModelsTest.nls_problems
     nls_from_T = eval(Meta.parse(lowercase(problem) * "_autodiff"))


### PR DESCRIPTION
I catch a bug where with the current system calling `hprod` and `hess` allocate because the vector `y` is expected of size `ncon` and not `nnln`.

#178 