### PR TITLE
Remove Zygote in performance

### DIFF
--- a/docs/src/performance.md
+++ b/docs/src/performance.md
@@ -142,11 +142,10 @@ scalable_problems = meta[(meta.variable_nvar .== true) .& (meta.ncon .> 0), :nam
 ```
 
 ```@example ex3
-using NLPModelsJuMP, Zygote
+using NLPModelsJuMP
 list_backends = Dict(
   :forward => ADNLPModels.ForwardDiffADGradient,
   :reverse => ADNLPModels.ReverseDiffADGradient,
-  :zygote => ADNLPModels.ZygoteADGradient,
 )
 ```
 


### PR DESCRIPTION
I got the following error appeared out of nowhere:
```
[ Info:  marine with 1007 vars and 488 cons
ERROR: Need an adjoint for constructor Base.ReshapedArray{Float64, 3, SubArray{Float64, 1, Vector{Float64}, Tuple{UnitRange{Int64}}, true}, Tuple{}}. Gradient is of type Array{Float64, 3}
```