### PR TITLE
[documentation] Explain coloring and detector kwargs in sparse backends

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,6 +17,7 @@ makedocs(
     "Default backends" => "predefined.md",
     "Build a hybrid NLPModel" => "mixed.md",
     "Support multiple precision" => "generic.md",
+    "Sparse Jacobian and Hessian" => "sparse.md",
     "Performance tips" => "performance.md",
     "Reference" => "reference.md",
   ],

--- a/docs/src/backend.md
+++ b/docs/src/backend.md
@@ -11,7 +11,7 @@ The functions used internally to define the NLPModel API and the possible backen
 | --------- | ------------------- | -------------------- | --------------- | -------------- | -------------- |
 | `gradient` and `gradient!` | `ForwardDiffADGradient`/`GenericForwardDiffADGradient` | `ReverseDiffADGradient`/`GenericReverseDiffADGradient` | `ZygoteADGradient` | `EnzymeADGradient` | -- |
 | `jacobian` | `ForwardDiffADJacobian` | `ReverseDiffADJacobian` | `ZygoteADJacobian` | -- | `SparseADJacobian` |
-| `hessian` | `ForwardDiffADHessian` | `ReverseDiffADHessian` | `ZygoteADHessian` | -- | `SparseADHessian` |
+| `hessian` | `ForwardDiffADHessian` | `ReverseDiffADHessian` | `ZygoteADHessian` | -- | `SparseADHessian`/`SparseReverseADHessian` |
 | `Jprod` | `ForwardDiffADJprod`/`GenericForwardDiffADJprod` | `ReverseDiffADJprod`/`GenericReverseDiffADJprod` | `ZygoteADJprod` | -- | -- |
 | `Jtprod` | `ForwardDiffADJtprod`/`GenericForwardDiffADJtprod` | `ReverseDiffADJtprod`/`GenericReverseDiffADJtprod` | `ZygoteADJtprod` | -- | -- |
 | `Hvprod` | `ForwardDiffADHvprod`/`GenericForwardDiffADHvprod` | `ReverseDiffADHvprod`/`GenericReverseDiffADHvprod` | -- | -- | -- |

--- a/docs/src/mixed.md
+++ b/docs/src/mixed.md
@@ -1,4 +1,4 @@
-# Build an hybrid NLPModel
+# Build a hybrid NLPModel
 
 The package `ADNLPModels.jl` implements the [`NLPModel API`](https://github.com/JuliaSmoothOptimizers/NLPModels.jl) using automatic differentiation (AD) backends.
 It is also possible to build hybrid models that use AD to complete the implementation of a given `NLPModel`.

--- a/docs/src/mixed.md
+++ b/docs/src/mixed.md
@@ -1,4 +1,4 @@
-# Build a hybrid NLPModel
+# Build an hybrid NLPModel
 
 The package `ADNLPModels.jl` implements the [`NLPModel API`](https://github.com/JuliaSmoothOptimizers/NLPModels.jl) using automatic differentiation (AD) backends.
 It is also possible to build hybrid models that use AD to complete the implementation of a given `NLPModel`.

--- a/docs/src/predefined.md
+++ b/docs/src/predefined.md
@@ -46,35 +46,3 @@ It is possible to use these pre-defined backends using the keyword argument `bac
 nlp = ADNLPModel!(f, x0, lvar, uvar, c!, lcon, ucon, backend = :optimized)
 get_adbackend(nlp)
 ```
-
-## Hessian and Jacobian computations
-
-It is to be noted that by default the Jacobian and Hessian matrices are sparse.
-
-```@example ex1
-(get_nnzj(nlp), get_nnzh(nlp))  # number of nonzeros elements in the Jacobian and Hessian
-```
-
-```@example ex1
-f(x) = (x[1] - 1)^2
-T = Float64
-x0 = T[-1.2; 1.0]
-lvar, uvar = zeros(T, 2), ones(T, 2) # must be of same type than `x0`
-lcon, ucon = -T[0.5], T[0.5]
-c!(cx, x) = begin
-  cx[1] = x[2]
-  return cx
-end
-nlp = ADNLPModel!(f, x0, lvar, uvar, c!, lcon, ucon, backend = :optimized)
-(get_nnzj(nlp), get_nnzh(nlp))
-```
-
-```@example ex1
-x = rand(T, 2)
-jac(nlp, x)
-```
-
-The package [`SparseConnectivityTracer.jl`](https://github.com/adrhill/SparseConnectivityTracer.jl) is used to compute the sparsity pattern of Jacobians and Hessians.
-The evaluation of the number of directional derivatives and the seeds required to compute compressed Jacobians and Hessians is performed using [`SparseMatrixColorings.jl`](https://github.com/gdalle/SparseMatrixColorings.jl).
-As of release v0.8.1, it has replaced [`ColPack.jl`](https://github.com/exanauts/ColPack.jl).
-We acknowledge Guillaume Dalle (@gdalle), Adrian Hill (@adrhill), and Michel Schanen (@michel2323) for the development of these packages.

--- a/docs/src/sparse.md
+++ b/docs/src/sparse.md
@@ -1,0 +1,45 @@
+# Sparse Hessian and Jacobian computations
+
+It is to be noted that by default the Jacobian and Hessian are sparse.
+
+```@example ex1
+using ADNLPModels, NLPModels
+
+f(x) = (x[1] - 1)^2
+T = Float64
+x0 = T[-1.2; 1.0]
+lvar, uvar = zeros(T, 2), ones(T, 2) # must be of same type than `x0`
+lcon, ucon = -T[0.5], T[0.5]
+c!(cx, x) = begin
+  cx[1] = x[2]
+  return cx
+end
+nlp = ADNLPModel!(f, x0, lvar, uvar, c!, lcon, ucon, backend = :optimized)
+```
+
+```@example ex1
+(get_nnzj(nlp), get_nnzh(nlp))  # number of nonzeros elements in the Jacobian and Hessian
+```
+
+```@example ex1
+x = rand(T, 2)
+J = jac(nlp, x)
+```
+
+```@example ex1
+x = rand(T, 2)
+H = hess(nlp, x)
+```
+
+The available backend for sparse derivatives has keyword arguments (`detector` and `coloring`) to specify the sparsity pattern detector and the coloring algorithm, respectively.
+
+- **Detector**: A `detector` must be of type `ADTypes.AbstractSparsityDetector`. The default detector is `TracerSparsityDetector()` from the `SparseConnectivityTracer.jl` package.
+Prior to version 0.8.0, the default detector was `SymbolicSparsityDetector()` from `Symbolics.jl`.
+
+- **Coloring**: A `coloring` must be of type `ADTypes.AbstractColoringAlgorithm`.
+The default algorithm is `GreedyColoringAlgorithm()` from the `SparseMatrixColorings.jl` package.
+
+The package [`SparseConnectivityTracer.jl`](https://github.com/adrhill/SparseConnectivityTracer.jl) is used to compute the sparsity pattern of Jacobians and Hessians.
+The evaluation of the number of directional derivatives and the seeds required to compute compressed Jacobians and Hessians is performed using [`SparseMatrixColorings.jl`](https://github.com/gdalle/SparseMatrixColorings.jl).
+As of release v0.8.1, it has replaced [`ColPack.jl`](https://github.com/exanauts/ColPack.jl).
+We acknowledge Guillaume Dalle (@gdalle), Adrian Hill (@adrhill), and Michel Schanen (@michel2323) for the development of these packages.

--- a/docs/src/sparse.md
+++ b/docs/src/sparse.md
@@ -31,13 +31,14 @@ x = rand(T, 2)
 H = hess(nlp, x)
 ```
 
-The available backend for sparse derivatives has keyword arguments (`detector` and `coloring`) to specify the sparsity pattern detector and the coloring algorithm, respectively.
+The available backends for sparse derivatives (`SparseADJacobian`, `SparseADHessian` and `SparseReverseADHessian`) have keyword arguments `detector` and `coloring` to specify the sparsity pattern detector and the coloring algorithm, respectively.
 
-- **Detector**: A `detector` must be of type `ADTypes.AbstractSparsityDetector`. The default detector is `TracerSparsityDetector()` from the `SparseConnectivityTracer.jl` package.
+- **Detector**: A `detector` must be of type `ADTypes.AbstractSparsityDetector`.
+The default detector is `TracerSparsityDetector()` from the package `SparseConnectivityTracer.jl`.
 Prior to version 0.8.0, the default detector was `SymbolicSparsityDetector()` from `Symbolics.jl`.
 
 - **Coloring**: A `coloring` must be of type `ADTypes.AbstractColoringAlgorithm`.
-The default algorithm is `GreedyColoringAlgorithm()` from the `SparseMatrixColorings.jl` package.
+The default algorithm is `GreedyColoringAlgorithm()` from the package `SparseMatrixColorings.jl`.
 
 The package [`SparseConnectivityTracer.jl`](https://github.com/adrhill/SparseConnectivityTracer.jl) is used to compute the sparsity pattern of Jacobians and Hessians.
 The evaluation of the number of directional derivatives and the seeds required to compute compressed Jacobians and Hessians is performed using [`SparseMatrixColorings.jl`](https://github.com/gdalle/SparseMatrixColorings.jl).

--- a/src/sparse_hessian.jl
+++ b/src/sparse_hessian.jl
@@ -20,7 +20,7 @@ function SparseADHessian(
   ncon,
   c!;
   x0::S = rand(nvar),
-  alg::AbstractColoringAlgorithm = GreedyColoringAlgorithm(),
+  coloring::AbstractColoringAlgorithm = GreedyColoringAlgorithm(),
   detector::AbstractSparsityDetector = TracerSparsityDetector(),
   kwargs...,
 ) where {S}
@@ -28,7 +28,7 @@ function SparseADHessian(
   H = compute_hessian_sparsity(f, nvar, c!, ncon, detector = detector)
 
   # TODO: use ADTypes.symmetric_coloring instead if you have the right decompression
-  colors = ADTypes.column_coloring(H, alg)
+  colors = ADTypes.column_coloring(H, coloring)
   ncolors = maximum(colors)
 
   d = BitVector(undef, nvar)
@@ -93,14 +93,14 @@ function SparseReverseADHessian(
   ncon,
   c!;
   x0::AbstractVector{T} = rand(nvar),
-  alg::AbstractColoringAlgorithm = GreedyColoringAlgorithm(),
+  coloring::AbstractColoringAlgorithm = GreedyColoringAlgorithm(),
   detector::AbstractSparsityDetector = TracerSparsityDetector(),
   kwargs...,
 ) where {T}
   H = compute_hessian_sparsity(f, nvar, c!, ncon, detector = detector)
 
   # TODO: use ADTypes.symmetric_coloring instead if you have the right decompression
-  colors = ADTypes.column_coloring(H, alg)
+  colors = ADTypes.column_coloring(H, coloring)
   ncolors = maximum(colors)
 
   d = BitVector(undef, nvar)

--- a/src/sparse_jacobian.jl
+++ b/src/sparse_jacobian.jl
@@ -15,7 +15,7 @@ function SparseADJacobian(
   ncon,
   c!;
   x0::AbstractVector{T} = rand(nvar),
-  alg::AbstractColoringAlgorithm = GreedyColoringAlgorithm(),
+  coloring::AbstractColoringAlgorithm = GreedyColoringAlgorithm(),
   detector::AbstractSparsityDetector = TracerSparsityDetector(),
   kwargs...,
 ) where {T}
@@ -23,7 +23,7 @@ function SparseADJacobian(
   J = compute_jacobian_sparsity(c!, output, x0, detector = detector)
 
   # TODO: use ADTypes.row_coloring instead if you have the right decompression and some heuristic recommends it
-  colors = ADTypes.column_coloring(J, alg)
+  colors = ADTypes.column_coloring(J, coloring)
   ncolors = maximum(colors)
 
   d = BitVector(undef, nvar)


### PR DESCRIPTION
Related to #247 
@gdalle 

I renamed the keyword argument for the coloring algorithm, but I believe it's safe to do so.
Since this option was not documented previously, I don't expect any users to rely on the `alg` option.