### PR TITLE
Don't test on nightly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,7 +12,7 @@ jobs:
         version:
           - 'lts'
           - '1'
-          - 'res'
+          - 'pre'
         os:
           - ubuntu-latest
         arch:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,9 +10,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.6'
+          - 'lts'
           - '1'
-          - 'nightly'
+          - 'res'
         os:
           - ubuntu-latest
         arch:


### PR DESCRIPTION
Update the CI script with the new options `'lts'` and `'pre'` (for prerelease), more stable and adaptive than `'1.6'` and `'nightly'`