### PR TITLE
[documentation] Explain how we can provide a sparsity pattern

### DIFF
--- a/docs/src/sparse.md
+++ b/docs/src/sparse.md
@@ -89,11 +89,7 @@ ucon = 0.5 * ones(T, ncon)
 J_backend = ADNLPModels.SparseADJacobian(nvar, f, ncon, c!, J)
 H_backend = ADNLPModels.SparseADHessian(nvar, f, ncon, c!, H)
 
-nlp = ADNLPModel!(f, x0, lvar, uvar, c!, lcon, ucon, jacobian_backend=ADNLPModels.EmptyADbackend, hessian_backend=ADNLPModels.EmptyADbackend)
-# nlp = ADNLPModel!(f, x0, lvar, uvar, c!, lcon, ucon, matrix_free=true)  # Equivalent to the previous line
-
-set_adbackend!(nlp, jacobian_backend=J_backend)
-set_adbackend!(nlp, hessian_backend=H_backend)
+nlp = ADNLPModel!(f, x0, lvar, uvar, c!, lcon, ucon, jacobian_backend=J_backend, hessian_backend=H_backend)
 ```
 
 The package [`SparseConnectivityTracer.jl`](https://github.com/adrhill/SparseConnectivityTracer.jl) is used to compute the sparsity pattern of Jacobians and Hessians.


### PR DESCRIPTION
@tmigot It seems that we can't create an `ADNLPModel` / `ADNLSModel` with an initialized AD backend.
I wanted to create `nlp` with the following constructor:
```julia
nlp = ADNLPModel!(f, x0, lvar, uvar, c!, lcon, ucon, acobian_backend=J_backend,hessian_backend=H_backend)
```
but the code [here](https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl/blob/main/src/ad.jl#L85-L93) wants to call the constructor of an `ADNLPModels.ADBackend`.
We can use `set_adbackend!` as a workaround.

Related to https://github.com/JuliaSmoothOptimizers/ADNLPModels.jl/pull/284 and https://github.com/control-toolbox/CTDirect.jl/issues/183
cc @jbcaillau
