### PR TITLE
Remove ct-registry for OptimalControl.jl

### DIFF
--- a/.github/workflows/Breakage.yml
+++ b/.github/workflows/Breakage.yml
@@ -56,9 +56,6 @@ jobs:
           set -v
           mkdir -p ./pr
           echo "${{ github.event.number }}" > ./pr/NR
-          if [ $URL == "control-toolbox/OptimalControl.jl" ]; then
-            julia -e 'using Pkg; Pkg.Registry.add(RegistrySpec(url = "https://github.com/control-toolbox/ct-registry.git"))'
-          fi
           git clone https://github.com/$URL
           export PKG=$(echo $URL | cut -f2 -d/)
           cd $PKG


### PR DESCRIPTION
I have remove in `.github/workflows/Breakage.yml` the following lines:

```yml
if [ $URL == "control-toolbox/OptimalControl.jl" ]; then
    julia -e 'using Pkg; Pkg.Registry.add(RegistrySpec(url = "https://github.com/control-toolbox/ct-registry.git"))'
fi
```

since now OptimalControl.jl is in the General registry. There no need to add `ct-registry` anymore.
