### PR TITLE
Provide an option to exclude some AD backends

### DIFF
--- a/src/ad.jl
+++ b/src/ad.jl
@@ -16,6 +16,7 @@ The default constructors are
     ADModelNLSBackend(nvar, F!, nequ, ncon = 0, c = (args...) -> []; show_time::Bool = false, kwargs...)
 
 If `show_time` is set to `true`, it prints the time used to generate each backend.
+If `excluded_backend` is not an empty array `Symbol[]`, the excluded backends will be set to `EmptyADbackend`.
 
 The remaining `kwargs` are either the different backends as listed below or arguments passed to the backend's constructors:
   - `gradient_backend = ForwardDiffADGradient`;
@@ -54,9 +55,10 @@ function ADModelBackend(
   backend::Symbol = :default,
   matrix_free::Bool = false,
   show_time::Bool = false,
-  gradient_backend = get_default_backend(:gradient_backend, backend),
-  hprod_backend = get_default_backend(:hprod_backend, backend),
-  hessian_backend = get_default_backend(:hessian_backend, backend, matrix_free),
+  excluded_backend::Vector{Symbol} = Symbol[],
+  gradient_backend = get_default_backend(:gradient_backend, backend; excluded_backend),
+  hprod_backend = get_default_backend(:hprod_backend, backend; excluded_backend),
+  hessian_backend = get_default_backend(:hessian_backend, backend, matrix_free; excluded_backend),
   kwargs...,
 )
   c! = (args...) -> []
@@ -116,13 +118,14 @@ function ADModelBackend(
   backend::Symbol = :default,
   matrix_free::Bool = false,
   show_time::Bool = false,
-  gradient_backend = get_default_backend(:gradient_backend, backend),
-  hprod_backend = get_default_backend(:hprod_backend, backend),
-  jprod_backend = get_default_backend(:jprod_backend, backend),
-  jtprod_backend = get_default_backend(:jtprod_backend, backend),
-  jacobian_backend = get_default_backend(:jacobian_backend, backend, matrix_free),
-  hessian_backend = get_default_backend(:hessian_backend, backend, matrix_free),
-  ghjvprod_backend = get_default_backend(:ghjvprod_backend, backend),
+  excluded_backend::Vector{Symbol} = Symbol[],
+  gradient_backend = get_default_backend(:gradient_backend, backend; excluded_backend),
+  hprod_backend = get_default_backend(:hprod_backend, backend; excluded_backend),
+  jprod_backend = get_default_backend(:jprod_backend, backend; excluded_backend),
+  jtprod_backend = get_default_backend(:jtprod_backend, backend; excluded_backend),
+  jacobian_backend = get_default_backend(:jacobian_backend, backend, matrix_free; excluded_backend),
+  hessian_backend = get_default_backend(:hessian_backend, backend, matrix_free; excluded_backend),
+  ghjvprod_backend = get_default_backend(:ghjvprod_backend, backend; excluded_backend),
   kwargs...,
 )
   GB = gradient_backend
@@ -218,14 +221,15 @@ function ADModelNLSBackend(
   backend::Symbol = :default,
   matrix_free::Bool = false,
   show_time::Bool = false,
-  gradient_backend = get_default_backend(:gradient_backend, backend),
-  hprod_backend = get_default_backend(:hprod_backend, backend),
-  hessian_backend = get_default_backend(:hessian_backend, backend, matrix_free),
-  hprod_residual_backend = get_default_backend(:hprod_residual_backend, backend),
-  jprod_residual_backend = get_default_backend(:jprod_residual_backend, backend),
-  jtprod_residual_backend = get_default_backend(:jtprod_residual_backend, backend),
-  jacobian_residual_backend = get_default_backend(:jacobian_residual_backend, backend, matrix_free),
-  hessian_residual_backend = get_default_backend(:hessian_residual_backend, backend, matrix_free),
+  excluded_backend::Vector{Symbol} = Symbol[],
+  gradient_backend = get_default_backend(:gradient_backend, backend; excluded_backend),
+  hprod_backend = get_default_backend(:hprod_backend, backend; excluded_backend),
+  hessian_backend = get_default_backend(:hessian_backend, backend, matrix_free; excluded_backend),
+  hprod_residual_backend = get_default_backend(:hprod_residual_backend, backend; excluded_backend),
+  jprod_residual_backend = get_default_backend(:jprod_residual_backend, backend; excluded_backend),
+  jtprod_residual_backend = get_default_backend(:jtprod_residual_backend, backend; excluded_backend),
+  jacobian_residual_backend = get_default_backend(:jacobian_residual_backend, backend, matrix_free; excluded_backend),
+  hessian_residual_backend = get_default_backend(:hessian_residual_backend, backend, matrix_free; excluded_backend),
   kwargs...,
 )
   function F(x; nequ = nequ)
@@ -344,18 +348,19 @@ function ADModelNLSBackend(
   backend::Symbol = :default,
   matrix_free::Bool = false,
   show_time::Bool = false,
-  gradient_backend = get_default_backend(:gradient_backend, backend),
-  hprod_backend = get_default_backend(:hprod_backend, backend),
-  jprod_backend = get_default_backend(:jprod_backend, backend),
-  jtprod_backend = get_default_backend(:jtprod_backend, backend),
-  jacobian_backend = get_default_backend(:jacobian_backend, backend, matrix_free),
-  hessian_backend = get_default_backend(:hessian_backend, backend, matrix_free),
-  ghjvprod_backend = get_default_backend(:ghjvprod_backend, backend),
-  hprod_residual_backend = get_default_backend(:hprod_residual_backend, backend),
-  jprod_residual_backend = get_default_backend(:jprod_residual_backend, backend),
-  jtprod_residual_backend = get_default_backend(:jtprod_residual_backend, backend),
-  jacobian_residual_backend = get_default_backend(:jacobian_residual_backend, backend, matrix_free),
-  hessian_residual_backend = get_default_backend(:hessian_residual_backend, backend, matrix_free),
+  excluded_backend::Vector{Symbol} = Symbol[],
+  gradient_backend = get_default_backend(:gradient_backend, backend; excluded_backend),
+  hprod_backend = get_default_backend(:hprod_backend, backend; excluded_backend),
+  jprod_backend = get_default_backend(:jprod_backend, backend; excluded_backend),
+  jtprod_backend = get_default_backend(:jtprod_backend, backend; excluded_backend),
+  jacobian_backend = get_default_backend(:jacobian_backend, backend, matrix_free; excluded_backend),
+  hessian_backend = get_default_backend(:hessian_backend, backend, matrix_free; excluded_backend),
+  ghjvprod_backend = get_default_backend(:ghjvprod_backend, backend; excluded_backend),
+  hprod_residual_backend = get_default_backend(:hprod_residual_backend, backend; excluded_backend),
+  jprod_residual_backend = get_default_backend(:jprod_residual_backend, backend; excluded_backend),
+  jtprod_residual_backend = get_default_backend(:jtprod_residual_backend, backend; excluded_backend),
+  jacobian_residual_backend = get_default_backend(:jacobian_residual_backend, backend, matrix_free; excluded_backend),
+  hessian_residual_backend = get_default_backend(:hessian_residual_backend, backend, matrix_free; excluded_backend),
   kwargs...,
 )
   function F(x; nequ = nequ)

--- a/src/ad.jl
+++ b/src/ad.jl
@@ -16,7 +16,7 @@ The default constructors are
     ADModelNLSBackend(nvar, F!, nequ, ncon = 0, c = (args...) -> []; show_time::Bool = false, kwargs...)
 
 If `show_time` is set to `true`, it prints the time used to generate each backend.
-If `excluded_backend` is not an empty array `Symbol[]`, the excluded backends will be set to `EmptyADbackend`.
+`excluded_backend` is the list of backends that are not used and will be set to `EmptyADbackend`.
 
 The remaining `kwargs` are either the different backends as listed below or arguments passed to the backend's constructors:
   - `gradient_backend = ForwardDiffADGradient`;

--- a/src/predefined_backend.jl
+++ b/src/predefined_backend.jl
@@ -96,19 +96,27 @@ function get_default_backend(meth::Symbol, args...; kwargs...)
   return get_default_backend(Val(meth), args...; kwargs...)
 end
 
-function get_default_backend(::Val{sym}, backend, args...; kwargs...) where {sym}
-  return predefined_backend[backend][sym]
+function get_default_backend(::Val{sym}, backend, args...; excluded_backend::Vector{Symbol}=Symbol[], kwargs...) where {sym}
+  backend = (sym in excluded_backend) ? EmptyADbackend : predefined_backend[backend][sym]
+  return backend
 end
 
-function get_default_backend(::Val{:jacobian_backend}, backend, matrix_free::Bool = false)
-  return matrix_free ? EmptyADbackend : predefined_backend[backend][:jacobian_backend]
+function get_default_backend(::Val{:jacobian_backend}, backend, matrix_free::Bool = false; excluded_backend::Vector{Symbol}=Symbol[])
+  backend = (matrix_free || :jacobian_backend in excluded_backend) ? EmptyADbackend : predefined_backend[backend][:jacobian_backend]
+  return backend
 end
-function get_default_backend(::Val{:hessian_backend}, backend, matrix_free::Bool = false)
-  return matrix_free ? EmptyADbackend : predefined_backend[backend][:hessian_backend]
+
+function get_default_backend(::Val{:hessian_backend}, backend, matrix_free::Bool = false; excluded_backend::Vector{Symbol}=Symbol[])
+  backend = (matrix_free || :hessian_backend in excluded_backend) ? EmptyADbackend : predefined_backend[backend][:hessian_backend]
+  return backend
 end
-function get_default_backend(::Val{:jacobian_residual_backend}, backend, matrix_free::Bool = false)
-  return matrix_free ? EmptyADbackend : predefined_backend[backend][:jacobian_residual_backend]
+
+function get_default_backend(::Val{:jacobian_residual_backend}, backend, matrix_free::Bool = false; excluded_backend::Vector{Symbol}=Symbol[])
+  backend = (matrix_free || :jacobian_residual_backend in excluded_backend) ? EmptyADbackend : predefined_backend[backend][:jacobian_residual_backend]
+  return backend
 end
-function get_default_backend(::Val{:hessian_residual_backend}, backend, matrix_free::Bool = false)
-  return matrix_free ? EmptyADbackend : predefined_backend[backend][:hessian_residual_backend]
+
+function get_default_backend(::Val{:hessian_residual_backend}, backend, matrix_free::Bool = false; excluded_backend::Vector{Symbol}=Symbol[])
+  backend = (matrix_free || sym in :hessian_residual_backend) ? EmptyADbackend : predefined_backend[backend][:hessian_residual_backend]
+  return backend
 end

--- a/src/predefined_backend.jl
+++ b/src/predefined_backend.jl
@@ -117,6 +117,6 @@ function get_default_backend(::Val{:jacobian_residual_backend}, backend, matrix_
 end
 
 function get_default_backend(::Val{:hessian_residual_backend}, backend, matrix_free::Bool = false; excluded_backend::Vector{Symbol}=Symbol[])
-  backend = (matrix_free || sym in :hessian_residual_backend) ? EmptyADbackend : predefined_backend[backend][:hessian_residual_backend]
+  backend = (matrix_free || :hessian_residual_backend in excluded_backend) ? EmptyADbackend : predefined_backend[backend][:hessian_residual_backend]
   return backend
 end


### PR DESCRIPTION
close #324 
cc @jbcaillau @PierreMartinon
It will be easier for you to exclude some `ADbackend` with the option `exclude_backend`.
```julia
using ADNLPModels, NLPModels

f(x) = (x[1] - 1)^2
T = Float64
x0 = T[-1.2; 1.0]
lvar, uvar = zeros(T, 2), ones(T, 2)
lcon, ucon = -T[0.5], T[0.5]
c!(cx, x) = begin
  cx[1] = x[2]
  return cx
end
nlp = ADNLPModel!(f, x0, lvar, uvar, c!, lcon, ucon, backend = :optimized,
                  excluded_backend=[:jprod_backend, :jtprod_backend, :hprod_backend, :ghjvprod_backend])
```
```julia
ADNLPModel - Model with automatic differentiation backend ADModelBackend{
  ReverseDiffADGradient,
  EmptyADbackend,
  EmptyADbackend,
  EmptyADbackend,
  SparseADJacobian,
  SparseReverseADHessian,
  EmptyADbackend,
}
```