### PR TITLE
Robust options for Enzyme

### DIFF
--- a/ext/ADNLPModelsEnzymeExt.jl
+++ b/ext/ADNLPModelsEnzymeExt.jl
@@ -5,15 +5,15 @@ using ADNLPModels, NLPModels
 using SparseMatrixColorings
 using Enzyme
 
-# Configure Enzyme for robustness
-Enzyme.API.strictAliasing!(false)   # handle Union types in Printf/@sprintf
-Enzyme.API.looseTypeAnalysis!(true) # handle unresolved types in complex structs
+# Configure Enzyme for robustness. This should be in the user code.
+# Enzyme.API.strictAliasing!(false)   # handle Union types in Printf/@sprintf
+# Enzyme.API.looseTypeAnalysis!(true) # handle unresolved types in complex structs
 
 function _gradient!(dx, f, x)
   Enzyme.make_zero!(dx)
   Enzyme.autodiff(
     Enzyme.set_runtime_activity(Enzyme.Reverse),
-    f,
+    Enzyme.Const(f),
     Enzyme.Active,
     Enzyme.Duplicated(x, dx),
   )
@@ -36,7 +36,7 @@ function _gradient!(dx, ℓ, x, y, obj_weight, cx)
   dcx = Enzyme.make_zero(cx)
   Enzyme.autodiff(
     Enzyme.set_runtime_activity(Enzyme.Reverse),
-    ℓ,
+    Enzyme.Const(ℓ),
     Enzyme.Active,
     Enzyme.Duplicated(x, dx),
     Enzyme.Const(y),


### PR DESCRIPTION
Alexis, you had issues with OptimalControl.jl and Enzyme. I've set here the most robust options for Enzyme. Maybe it works now. The compile time might be slower now.

I couldn't run your example. It gives an unrelated error. Maybe I use it wrong.

```julia
╰─$ julia --project enzyme.jl                                                                                                                                           1 ↵
ERROR: LoadError: MethodError: no method matching iterate(::CTDirect.DOCP{CTDirect.Midpoint, Model{CTModels.Autonomous, CTModels.TimesModel{CTModels.FixedTimeModel{Int64}, CTModels.FixedTimeModel{Float64}}, CTModels.StateModel, CTModels.ControlModel, CTModels.EmptyVariableModel, var"#fun##296#16", CTModels.LagrangeObjectiveModel{var"#fun##301#17"}, CTModels.ConstraintsModel{Tuple{Vector{Float64}, CTModels.var"#path_cons_nl!#build##1"{Tuple{}, Vector{Int64}, Int64}, Vector{Float64}, Vector{Symbol}}, Tuple{Vector{Float64}, var"#fun##289#15", Vector{Float64}, Vector{Symbol}}, Tuple{Vector{Float64}, Vector{Int64}, Vector{Float64}, Vector{Symbol}}, Tuple{Vector{Float64}, Vector{Int64}, Vector{Float64}, Vector{Symbol}}, Tuple{Vector{Float64}, Vector{Int64}, Vector{Float64}, Vector{Symbol}}}, var"#18#19"}, CTDirect.ADNLPBackend})
The function `iterate` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  iterate(::Pkg.Resolve.NodePerm, Any...)
   @ Pkg ~/.julia/juliaup/julia-1.12.5+0.x64.linux.gnu/share/julia/stdlib/v1.12/Pkg/src/Resolve/maxsum.jl:242
  iterate(::Pipe, ::Int64)
   @ Base stream.jl:1297
  iterate(::Pipe)
   @ Base stream.jl:1296
  ...

Stacktrace:
 [1] indexed_iterate(I::CTDirect.DOCP{CTDirect.Midpoint, Model{CTModels.Autonomous, CTModels.TimesModel{CTModels.FixedTimeModel{Int64}, CTModels.FixedTimeModel{Float64}}, CTModels.StateModel, CTModels.ControlModel, CTModels.EmptyVariableModel, var"#fun##296#16", CTModels.LagrangeObjectiveModel{var"#fun##301#17"}, CTModels.ConstraintsModel{Tuple{Vector{Float64}, CTModels.var"#path_cons_nl!#build##1"{Tuple{}, Vector{Int64}, Int64}, Vector{Float64}, Vector{Symbol}}, Tuple{Vector{Float64}, var"#fun##289#15", Vector{Float64}, Vector{Symbol}}, Tuple{Vector{Float64}, Vector{Int64}, Vector{Float64}, Vector{Symbol}}, Tuple{Vector{Float64}, Vector{Int64}, Vector{Float64}, Vector{Symbol}}, Tuple{Vector{Float64}, Vector{Int64}, Vector{Float64}, Vector{Symbol}}}, var"#18#19"}, CTDirect.ADNLPBackend}, i::Int64)
   @ Base ./tuple.jl:165
 [2] top-level scope
   @ ~/project/enzyme.jl:24
 ```