### PR TITLE
Update Buildkite pipeline for the new JuliaGPU cluster

### DIFF
--- a/.buildkite/pipeline-julia.yml
+++ b/.buildkite/pipeline-julia.yml
@@ -1,0 +1,13 @@
+steps:
+  - label: "CPUs -- Enzyme.jl"
+    plugins:
+      - JuliaCI/julia#v1:
+          version: "1.10"
+    agents:
+      queue: "juliaecosystem"
+      os: "linux"
+      arch: "x86_64"
+    command: |
+      julia --color=yes --project=test -e 'using Pkg; Pkg.add("Enzyme"); Pkg.develop(path="."); Pkg.instantiate()'
+      julia --color=yes --project=test -e 'include("test/enzyme.jl")'
+    timeout_in_minutes: 30

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -4,22 +4,8 @@ steps:
       - JuliaCI/julia#v1:
           version: "1.10"
     agents:
-      queue: "juliagpu"
-      cuda: "*"
+      queue: "cuda"
     command: |
       julia --color=yes --project=test -e 'using Pkg; Pkg.add("CUDA"); Pkg.develop(path="."); Pkg.instantiate()'
       julia --color=yes --project=test -e 'include("test/gpu.jl")'
-    timeout_in_minutes: 30
-
-  - label: "CPUs -- Enzyme.jl"
-    plugins:
-      - JuliaCI/julia#v1:
-          version: "1.10"
-    agents:
-      queue: "juliaecosystem"
-      os: "linux"
-      arch: "x86_64"
-    command: |
-      julia --color=yes --project=test -e 'using Pkg; Pkg.add("Enzyme"); Pkg.develop(path="."); Pkg.instantiate()'
-      julia --color=yes --project=test -e 'include("test/enzyme.jl")'
     timeout_in_minutes: 30


### PR DESCRIPTION
The JuliaGPU Buildkite agents have moved to a dedicated cluster, where the single `juliagpu` queue has been split into per-backend queues. Steps now select agents using `queue: "cuda"`, `queue: "rocm"` or `queue: "oneapi"` instead of `queue: "juliagpu"` combined with a `cuda`/`rocm`/`intel` tag.

Since queues are now scoped to a cluster, a single pipeline can no longer mix JuliaGPU and `juliaecosystem` jobs: `pipeline.yml` now contains only the GPU jobs, while the `juliaecosystem` steps have moved unmodified to `pipeline-julia.yml`, to be uploaded by a separate pipeline in the ecosystem cluster once that is back online.

This change only affects agent selection; the steps themselves are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)